### PR TITLE
File watcher!

### DIFF
--- a/.vs/restore.dg
+++ b/.vs/restore.dg
@@ -1,0 +1,2 @@
+#:C:\Users\Darrell\Source\Repos\Smidge\test\Smidge.Tests\Smidge.Tests.xproj
+C:\Users\Darrell\Source\Repos\Smidge\test\Smidge.Tests\Smidge.Tests.xproj|C:\Users\Darrell\Source\Repos\Smidge\src\Smidge\Smidge.xproj

--- a/src/Smidge.Web/wwwroot/Js/test1.js
+++ b/src/Smidge.Web/wwwroot/Js/test1.js
@@ -1,1 +1,1 @@
-﻿$("#jsOutput").append("<br/><span>/Js/test1.js</span>")
+﻿$("#jsOutput").append("<br/><span>/Js/test1.js a</span>")

--- a/src/Smidge/FileProcessors/CssImportProcessor.cs
+++ b/src/Smidge/FileProcessors/CssImportProcessor.cs
@@ -49,23 +49,26 @@ namespace Smidge.FileProcessors
                 else
                 {
                     //it's internal (in theory)
-                    var filePath = _fileSystemHelper.MapWebPath(path.StartsWith("/") ? path : string.Format("~/{0}", path));
-                    if (System.IO.File.Exists(filePath))
-                    {
-                        var content = await _fileSystemHelper.ReadContentsAsync(filePath);
-                        
-                        //This needs to be put back through the whole pre-processor pipeline before being added,
-                        // so we'll clone the original webfile with it's new path, this will inherit the whole pipeline,
-                        // and then we'll execute the pipeline for that file
-                        var clone = fileProcessContext.WebFile.Duplicate(path);
-                        var processed = await clone.Pipeline.ProcessAsync(new FileProcessContext(content, clone));
+                    var filePath = _fileSystemHelper.GetFileInfo(path);
+                    var content = await _fileSystemHelper.ReadContentsAsync(filePath);
 
-                        sb.Append(processed);
-                    }
-                    else
-                    {
-                        //TODO: Need to log this
-                    }
+                    //This needs to be put back through the whole pre-processor pipeline before being added,
+                    // so we'll clone the original webfile with it's new path, this will inherit the whole pipeline,
+                    // and then we'll execute the pipeline for that file
+                    var clone = fileProcessContext.WebFile.Duplicate(path);
+                    var processed = await clone.Pipeline.ProcessAsync(new FileProcessContext(content, clone));
+
+                    sb.Append(processed);
+
+                    ////  _fileSystemHelper.MapWebPath(path.StartsWith("/") ? path : string.Format("~/{0}", path));
+                    //if (System.IO.File.Exists(filePath))
+                    //{
+                       
+                    //}
+                    //else
+                    //{
+                    //    //TODO: Need to log this
+                    //}
                 }
 
             }

--- a/src/Smidge/FileProcessors/PreProcessManager.cs
+++ b/src/Smidge/FileProcessors/PreProcessManager.cs
@@ -25,7 +25,7 @@ namespace Smidge.FileProcessors
         public async Task ProcessAndCacheFileAsync(IWebFile file)
         {
             if (file == null) throw new ArgumentNullException(nameof(file));
-			if (file.Pipeline == null) throw new ArgumentNullException(string.Format("{0}.Pipeline", nameof(file)));
+            if (file.Pipeline == null) throw new ArgumentNullException(string.Format("{0}.Pipeline", nameof(file)));
 
             switch (file.DependencyType)
             {
@@ -76,19 +76,30 @@ namespace Smidge.FileProcessors
 
             if (!File.Exists(cacheFile))
             {
-                var filePath = _fileSystemHelper.MapWebPath(file.FilePath);
-                
-                //doesn't exist, throw as thsi shouldn't happen
-                if (File.Exists(filePath) == false) throw new FileNotFoundException("No file found with path " + filePath);
-
-                var contents = await _fileSystemHelper.ReadContentsAsync(filePath);
+                //  var filePath = _fileSystemHelper.MapWebPath(file.FilePath);
+                var fileInfo = _fileSystemHelper.GetFileInfo(file);
+                var contents = await _fileSystemHelper.ReadContentsAsync(fileInfo);
 
                 //process the file
                 var processed = await file.Pipeline.ProcessAsync(new FileProcessContext(contents, file));
 
                 //save it to the cache path
                 await _fileSystemHelper.WriteContentsAsync(cacheFile, processed);
+
+                // watch this file for changes:
+
+                _fileSystemHelper.Watch(file, (f) =>
+                {
+                    //
+                    var x = f;
+                    var message = "some file changed..";
+
+
+                });
             }
+
+
+
         }
 
     }

--- a/src/Smidge/FileSystemHelper.cs
+++ b/src/Smidge/FileSystemHelper.cs
@@ -128,7 +128,7 @@ namespace Smidge
                 var files = string.IsNullOrWhiteSpace(extensionFilter)
                     ? folderContents
                     : folderContents.Where(
-                        (a) => !a.IsDirectory && a.Exists && Path.GetExtension(a.PhysicalPath) == string.Format(".{0}", extensionFilter));
+                        (a) => !a.IsDirectory && a.Exists && Path.GetExtension(a.Name) == string.Format(".{0}", extensionFilter));
                 return files.Select(x => ReverseMapPath(folderPart, x));
             }
             else

--- a/src/Smidge/FileSystemHelper.cs
+++ b/src/Smidge/FileSystemHelper.cs
@@ -71,7 +71,7 @@ namespace Smidge
 
             if (!fileInfo.Exists)
             {
-                throw new FileNotFoundException($"No such file exists {fileInfo.PhysicalPath} (mapped from {path})", fileInfo.PhysicalPath);
+                throw new FileNotFoundException($"No such file exists {fileInfo.PhysicalPath ?? fileInfo.Name} (mapped from {filePath})", fileInfo.PhysicalPath);
             }
 
             return fileInfo;
@@ -159,16 +159,24 @@ namespace Smidge
         /// <returns></returns>
         public string ReverseMapPath(string subPath, IFileInfo fileInfo)
         {
-            var subPathDir = subPath.Replace("/", "\\");
-            var subPathIndex = fileInfo.PhysicalPath.IndexOf(subPathDir, StringComparison.OrdinalIgnoreCase);
-            var fileSubPath = fileInfo.PhysicalPath.Substring(subPathIndex);
-
-            var reversed = fileSubPath.Replace("\\", "/");
+            var reversed = subPath.Replace("\\", "/");
             if (!reversed.StartsWith("/"))
             {
-                reversed = "/" + reversed;
+                reversed = $"/{reversed}";
             }
-            return "~" + reversed;
+            //if (!reversed.StartsWith("~"))
+            //{
+            //    reversed = $"~{reversed}";
+            //}
+            if (!reversed.EndsWith(fileInfo.Name))
+            {
+                return $"~{reversed}/{fileInfo.Name}";
+            }
+            else
+            {
+                return $"~{reversed}";
+            }
+           
         }
 
         internal async Task<string> ReadContentsAsync(IFileInfo fileInfo)

--- a/src/Smidge/Models/IWebFile.cs
+++ b/src/Smidge/Models/IWebFile.cs
@@ -1,5 +1,6 @@
 ﻿using Smidge.FileProcessors;
 using System;
+using System.IO;
 
 namespace Smidge.Models
 {
@@ -24,5 +25,6 @@ namespace Smidge.Models
         /// file type will be applied.
         /// </summary>
         PreProcessPipeline Pipeline { get; set; }
+
     }
 }

--- a/test/Smidge.Tests/FileBatcherTests.cs
+++ b/test/Smidge.Tests/FileBatcherTests.cs
@@ -28,6 +28,11 @@ namespace Smidge.Tests
             var fileSystemHelper = new FileSystemHelper(hostingEnv, config, fileProvider.Object);          
             var batcher = new FileBatcher(fileSystemHelper, urlHelper, Mock.Of<IHasher>());
 
+            var file = new Mock<IFileInfo>();
+            file.Setup(a => a.IsDirectory).Returns(false);
+            file.SetupAllProperties();
+            fileProvider.Setup(x => x.GetFileInfo(It.IsAny<string>())).Returns(file.Object);
+
             //test a mix start/ending with external
             var result = batcher.GetCompositeFileCollectionForUrlGeneration(new IWebFile[] {
                     Mock.Of<IWebFile>(f => f.FilePath == "//cdnjs.cloudflare.com/ajax/libs/jquery/2.1.1/jquery.min.js"),

--- a/test/Smidge.Tests/FileSystemHelperTests.cs
+++ b/test/Smidge.Tests/FileSystemHelperTests.cs
@@ -77,95 +77,12 @@ namespace Smidge.Tests
 
             Assert.Equal("http://test.com/hello.js", result);
         }
+        
+        
+        
 
         [Fact]
-        public void Map_Path_Absolute()
-        {
-
-            var url = "/Js/Test1.js";
-            var fileProvider = new Mock<IFileProvider>();
-            var file = new Mock<IFileInfo>();
-            string filePath = "C:\\MySolution\\MyProject\\Js\\Test1.js";
-
-            file.Setup(x => x.Exists).Returns(true);
-            file.Setup(x => x.IsDirectory).Returns(false);
-            file.Setup(x => x.Name).Returns(System.IO.Path.GetFileName(url));
-            file.Setup(x => x.PhysicalPath).Returns(filePath);
-
-            fileProvider.Setup(x => x.GetFileInfo(It.IsAny<string>())).Returns(file.Object);
-
-            var urlHelper = new Mock<IUrlHelper>();
-            urlHelper.Setup(x => x.Content(It.IsAny<string>())).Returns<string>(s => s);
-            var helper = new FileSystemHelper(
-                Mock.Of<IHostingEnvironment>(x => x.WebRootPath == "C:\\MySolution\\MyProject" && x.WebRootFileProvider == fileProvider.Object),
-                Mock.Of<ISmidgeConfig>());
-
-            var result = helper.MapWebPath(url);
-
-            Assert.Equal(filePath, result);
-        }
-
-        [Fact]
-        public void Map_Path_Virtual_Path()
-        {
-
-            var webRootPath = "C:\\MySolution\\MyProject";
-
-            var url = "~/Js/Test1.js";
-
-            var fileProvider = new Mock<IFileProvider>();
-            var file = new Mock<IFileInfo>();
-            string filePath = Path.Combine(webRootPath, "Js\\Test1.js");
-
-            file.Setup(x => x.Exists).Returns(true);
-            file.Setup(x => x.IsDirectory).Returns(false);
-            file.Setup(x => x.Name).Returns(System.IO.Path.GetFileName(url));
-            file.Setup(x => x.PhysicalPath).Returns(filePath);
-
-            fileProvider.Setup(x => x.GetFileInfo(It.IsAny<string>())).Returns(file.Object);
-
-            var urlHelper = new Mock<IUrlHelper>();
-            urlHelper.Setup(x => x.Content(It.IsAny<string>())).Returns<string>(s => s);
-            var helper = new FileSystemHelper(
-                Mock.Of<IHostingEnvironment>(x => x.WebRootPath == webRootPath && x.WebRootFileProvider == fileProvider.Object),
-                Mock.Of<ISmidgeConfig>());
-
-            var result = helper.MapWebPath(url);
-
-            Assert.Equal(filePath, result);
-        }
-
-        [Fact]
-        public void Map_Path_Relative_Path()
-        {
-            var url = "Js/Test1.js";
-            var fileProvider = new Mock<IFileProvider>();
-
-            var webRootPath = "C:\\MySolution\\MyProject";
-            var file = new Mock<IFileInfo>();
-            string filePath = Path.Combine(webRootPath, "Js\\Test1.js");
-
-            file.Setup(x => x.Exists).Returns(true);
-            file.Setup(x => x.IsDirectory).Returns(false);
-            file.Setup(x => x.Name).Returns(System.IO.Path.GetFileName(url));
-            file.Setup(x => x.PhysicalPath).Returns(filePath);
-
-            fileProvider.Setup(x => x.GetFileInfo(It.IsAny<string>())).Returns(file.Object);
-
-            var urlHelper = new Mock<IUrlHelper>();
-            urlHelper.Setup(x => x.Content(It.IsAny<string>())).Returns<string>(s => s);
-            var helper = new FileSystemHelper(
-                Mock.Of<IHostingEnvironment>(x => x.WebRootPath == webRootPath && x.WebRootFileProvider == fileProvider.Object),
-                Mock.Of<ISmidgeConfig>());
-
-            var result = helper.MapWebPath(url);
-
-            Assert.Equal(filePath, result);
-        }
-
-
-        [Fact]
-        public void Map_Path_Non_Existent_File_Throws_Informative_Exception()
+        public void Get_File_Info_Non_Existent_File_Throws_Informative_Exception()
         {
 
             var webRootPath = "C:\\MySolution\\MyProject";
@@ -189,7 +106,7 @@ namespace Smidge.Tests
                 Mock.Of<IHostingEnvironment>(x => x.WebRootPath == webRootPath && x.WebRootFileProvider == fileProvider.Object),
                 Mock.Of<ISmidgeConfig>());
 
-            FileNotFoundException ex = Assert.Throws<FileNotFoundException>(() => helper.MapWebPath(url));
+            FileNotFoundException ex = Assert.Throws<FileNotFoundException>(() => helper.GetFileInfo(url));
 
             //    var result = helper.MapPath(url);
 

--- a/test/Smidge.Tests/project.json
+++ b/test/Smidge.Tests/project.json
@@ -1,15 +1,11 @@
 {
   "version": "1.0.0-*",
   "dependencies": {
-    "Smidge": {
-      "target": "project",
-      "version": "1.0.0-*"
-    },
-
     "moq.netcore": "4.4.0-beta8",
     "xunit": "2.1.0",
     "dotnet-test-xunit": "1.0.0-rc3-build10019",
-    "System.Diagnostics.TraceSource": "4.0.0-rc2-24027"
+    "System.Diagnostics.TraceSource": "4.0.0-rc2-24027",
+    "Smidge": "1.0.0"
   },
 
   "testRunner": "xunit",


### PR DESCRIPTION
Ok so have a quick look at this!

I have made some quick tweaks to demo an idea. 

`PreProcessManager` now watches the input files, and a delegate is invoked whenever one is edited.

To demonstrate this, start the website running, and put a break point somewhere in here within `PreProcessManager.ProcessFile()`
```
 _fileSystemHelper.Watch(file, (f) =>
                {
                    //
                    var x = f;
                    var message = "some file changed..";


                });
```

With the site running, edit a file like `test1.js` - you should find the break point is hit.

I think we can use this to: 

1. Re-execute the pipeline and update the cache / bundle files when things change?
2. Invalidate the client side cache some how, so the next request gets the new files?

Both those features would be big wins for development mode.

Need your input on this in order to work out if its truly viable, and how best to do it.

Also I made some minor tweeks. Smidge often assumes that an input file (`IWebFile`) is located on the physical disk. For example it would do File.Exists() checks. I changed this so that Smidge gets files through the `IFileProvider` which returns an `IFileInfo`. It uses `IFileInfo.Exists` instead. The beauty of this is that paths provided to smidge do not need to relate to physical file system, they just need to be files accessbile through the IFileProvider - so in theory they can come from anywhere as this is just a type of virtual directory. The default `IFileProvider` is normaly a PhsyicalFileProvider ofcourse, however in more complicated applications, it could be a CompositeFileProvider, providing access to files from many different sources - azure blob storage, embedded resources etc etc

Smidge does still rely on the Physical disk ofcourse, when it is creating the cache / bundle files, and thats absolutely fine.

