### PR TITLE
Fixes: Retrieve files based on their extension #87

### DIFF
--- a/src/Smidge/Controllers/SmidgeController.cs
+++ b/src/Smidge/Controllers/SmidgeController.cs
@@ -119,7 +119,7 @@ namespace Smidge.Controllers
                 //Get each file path to it's hashed location since that is what the pre-processed file will be saved as
                 Lazy<IFileInfo> fi;
                 var filePaths = files.Select(
-                    x => _fileSystemHelper.GetCacheFilePath(x, bundleOptions.FileWatchOptions.Enabled, bundle.Extension, bundle.CacheBuster, out fi));
+                    x => _fileSystemHelper.GetCacheFilePath(x, bundleOptions.FileWatchOptions.Enabled, Path.GetExtension(x.FilePath), bundle.CacheBuster, out fi));
 
                 using (var resultStream = await GetCombinedStreamAsync(filePaths, bundleContext))
                 {


### PR DESCRIPTION
Currently for predefined CSS bundles with `.less` files an empty 200 response is returned because the files are found based on the extension of the bundle rather than the file itself. Changing the searching of the files to use the extension of the file resolves this issue.

Resolves #87 