### PR TITLE
Added .net core 3.0 support

### DIFF
--- a/src/Smidge/Controllers/CompositeFileCacheFilterAttribute.cs
+++ b/src/Smidge/Controllers/CompositeFileCacheFilterAttribute.cs
@@ -75,7 +75,7 @@ namespace Smidge.Controllers
                 RequestModel file = null;
                 if (bundleFile != null)
                 {
-                    cacheBuster = _cacheBusterResolver.GetCacheBuster(bundleFile.Bundle.GetBundleOptions(_bundleManager, bundleFile.Debug).GetCacheBusterType());                        
+                    cacheBuster = _cacheBusterResolver.GetCacheBuster(bundleFile.FileBundle.GetBundleOptions(_bundleManager, bundleFile.Debug).GetCacheBusterType());                        
                 }
                 else
                 {

--- a/src/Smidge/FileSystemHelper.cs
+++ b/src/Smidge/FileSystemHelper.cs
@@ -22,12 +22,20 @@ namespace Smidge
     public sealed class FileSystemHelper
     {
         private readonly ISmidgeConfig _config;
+#if NETCORE3_0        
+        private readonly IWebHostEnvironment _hostingEnv;
+#else
         private readonly IHostingEnvironment _hostingEnv;
+#endif
         private readonly ConcurrentDictionary<string, SemaphoreSlim> _fileLocker = new ConcurrentDictionary<string, SemaphoreSlim>();
         private readonly IFileProvider _fileProvider;
         private readonly IHasher _hasher;
 
+#if NETCORE3_0        
+        public FileSystemHelper(IWebHostEnvironment hostingEnv, ISmidgeConfig config, IFileProvider fileProvider, IHasher hasher)
+#else
         public FileSystemHelper(IHostingEnvironment hostingEnv, ISmidgeConfig config, IFileProvider fileProvider, IHasher hasher)
+#endif
         {
             _hasher = hasher;
             _config = config;
@@ -35,14 +43,17 @@ namespace Smidge
             _fileProvider = fileProvider;
         }
 
+#if NETCORE3_0        
+        public FileSystemHelper(IWebHostEnvironment hostingEnv, ISmidgeConfig config, IHasher hasher)
+#else
         public FileSystemHelper(IHostingEnvironment hostingEnv, ISmidgeConfig config, IHasher hasher)
+#endif
         {
             _hasher = hasher;
             _config = config;
             _hostingEnv = hostingEnv;
             _fileProvider = hostingEnv.WebRootFileProvider;
         }
-
         public IFileInfo GetFileInfo(IWebFile webfile)
         {
             var path = webfile.FilePath.TrimStart(new[] { '~' });

--- a/src/Smidge/Models/BundleRequestModel.cs
+++ b/src/Smidge/Models/BundleRequestModel.cs
@@ -32,13 +32,13 @@ namespace Smidge.Models
             {
                 throw new InvalidOperationException("No bundle found with key " + FileKey);
             }
-            Bundle = bundle;
+            FileBundle = bundle;
 
             CacheBuster = cacheBusterResolver.GetCacheBuster(bundle.GetBundleOptions(bundleManager, Debug).GetCacheBusterType());                
         }
 
         public override ICacheBuster CacheBuster { get; }
-        public Bundle Bundle { get; }        
+        public Bundle FileBundle { get; }        
         public override string FileKey { get; }
     }
 }

--- a/src/Smidge/Properties/launchSettings.json
+++ b/src/Smidge/Properties/launchSettings.json
@@ -1,0 +1,27 @@
+{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:51530/",
+      "sslPort": 0
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "Smidge": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "http://localhost:51533/"
+    }
+  }
+}

--- a/src/Smidge/Smidge.csproj
+++ b/src/Smidge/Smidge.csproj
@@ -28,11 +28,5 @@
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.0.0" />
     </ItemGroup>
     <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0' ">
-        <!--
-        <PackageReference Include="Microsoft.AspNetCore.Routing" Version="3.0.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.TagHelpers" Version="2.2.0" />
-        <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
-        -->
     </ItemGroup>  
 </Project>

--- a/src/Smidge/Smidge.csproj
+++ b/src/Smidge/Smidge.csproj
@@ -1,27 +1,32 @@
-<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <AssemblyTitle>Smidge</AssemblyTitle>
-    <Description>A lightweight ASP.Net Core library for runtime CSS and JavaScript file management, minification, combination &amp; compression</Description>
-    <VersionPrefix>3.0.3</VersionPrefix>
-    <Copyright>Copyright © Shannon Deminick 2018</Copyright>
-    <Authors>Shannon Deminick</Authors>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <AssemblyName>Smidge</AssemblyName>
-    <PackageId>Smidge</PackageId>
-    <PackageTags>css;javascript;minify;compression;combination;aspnetcore</PackageTags>
-    <PackageProjectUrl>https://github.com/Shazwazza/Smidge/</PackageProjectUrl>
-    <PackageLicenseUrl>http://opensource.org/licenses/MIT</PackageLicenseUrl>
-    <PackageIconUrl>https://raw.githubusercontent.com/Shazwazza/Smidge/master/assets/logo-nuget.png</PackageIconUrl>
-    <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>git://github.com/Shazwazza/Smidge/</RepositoryUrl>
-  </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.0.0" />
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Properties\" />
-  </ItemGroup>
+﻿<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <AssemblyTitle>Smidge</AssemblyTitle>
+        <Description>A lightweight ASP.Net Core library for runtime CSS and JavaScript file management, minification, combination &amp; compression</Description>
+        <VersionPrefix>3.0.3</VersionPrefix>
+        <Copyright>Copyright © Shannon Deminick 2018</Copyright>
+        <Authors>Shannon Deminick</Authors>
+        <TargetFrameworks>netcoreapp3.0;netstandard2.0</TargetFrameworks>
+        <AssemblyName>Smidge</AssemblyName>
+        <PackageId>Smidge</PackageId>
+        <PackageTags>css;javascript;minify;compression;combination;aspnetcore</PackageTags>
+        <PackageProjectUrl>https://github.com/Shazwazza/Smidge/</PackageProjectUrl>
+        <PackageLicenseUrl>http://opensource.org/licenses/MIT</PackageLicenseUrl>
+        <PackageIconUrl>https://raw.githubusercontent.com/Shazwazza/Smidge/master/assets/logo-nuget.png</PackageIconUrl>
+        <RepositoryType>git</RepositoryType>
+        <RepositoryUrl>git://github.com/Shazwazza/Smidge/</RepositoryUrl>
+    </PropertyGroup>
+    <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.0.0" />
+    </ItemGroup>
+    <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0' ">
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.TagHelpers" Version="2.1.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.1.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.0" />
+    </ItemGroup>
+    <ItemGroup>
+        <Folder Include="Properties\" />
+    </ItemGroup>
 </Project>

--- a/src/Smidge/Smidge.csproj
+++ b/src/Smidge/Smidge.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
     <PropertyGroup>
         <AssemblyTitle>Smidge</AssemblyTitle>
         <Description>A lightweight ASP.Net Core library for runtime CSS and JavaScript file management, minification, combination &amp; compression</Description>
@@ -14,6 +14,12 @@
         <PackageIconUrl>https://raw.githubusercontent.com/Shazwazza/Smidge/master/assets/logo-nuget.png</PackageIconUrl>
         <RepositoryType>git</RepositoryType>
         <RepositoryUrl>git://github.com/Shazwazza/Smidge/</RepositoryUrl>
+        <ApplicationIcon />
+        <OutputType>Library</OutputType>
+        <StartupObject />
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+        <DefineConstants>$(DefineConstants);NETCORE3_0</DefineConstants>
     </PropertyGroup>
     <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
@@ -22,11 +28,11 @@
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.0.0" />
     </ItemGroup>
     <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0' ">
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.TagHelpers" Version="2.1.0" />
-        <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.1.0" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.0" />
-    </ItemGroup>
-    <ItemGroup>
-        <Folder Include="Properties\" />
-    </ItemGroup>
+        <!--
+        <PackageReference Include="Microsoft.AspNetCore.Routing" Version="3.0.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.TagHelpers" Version="2.2.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
+        -->
+    </ItemGroup>  
 </Project>

--- a/src/Smidge/SmidgeConfig.cs
+++ b/src/Smidge/SmidgeConfig.cs
@@ -21,7 +21,11 @@ namespace Smidge
         /// Constructor that will use a smidge.json configuration file in env.ApplicationBasePath
         /// </summary>
         /// <param name="env"></param>
+#if NETCORE3_0
+        public SmidgeConfig(IWebHostEnvironment env)
+#else
         public SmidgeConfig(IHostingEnvironment env)
+#endif
         {
             //  use smidge.json file if it exists for backwards compatibility.
             var cfg = new ConfigurationBuilder()

--- a/src/Smidge/SmidgeStartup.cs
+++ b/src/Smidge/SmidgeStartup.cs
@@ -55,15 +55,24 @@ namespace Smidge
             services.AddSingleton<PreProcessPipelineFactory>();
             services.AddSingleton<FileSystemHelper>(p =>
             {
+#if NETCORE3_0                     
+                var hosting = p.GetRequiredService<IWebHostEnvironment>();
+#else
                 var hosting = p.GetRequiredService<IHostingEnvironment>();
+#endif
                 var provider = fileProvider ?? hosting.WebRootFileProvider;
+
                 return new FileSystemHelper(hosting, p.GetRequiredService<ISmidgeConfig>(), provider, p.GetRequiredService<IHasher>());
             });
             services.AddSingleton<ISmidgeConfig>((p) =>
             {
                 if (smidgeConfiguration == null)
                 {
+#if NETCORE3_0                     
+                    return new SmidgeConfig(p.GetRequiredService<IWebHostEnvironment>());
+#else
                     return new SmidgeConfig(p.GetRequiredService<IHostingEnvironment>());
+#endif
                 }
                 return new SmidgeConfig(smidgeConfiguration);
             });

--- a/src/Smidge/SmidgeStartup.cs
+++ b/src/Smidge/SmidgeStartup.cs
@@ -94,7 +94,7 @@ namespace Smidge
             {
                 var options = app.ApplicationServices.GetRequiredService<IOptions<SmidgeOptions>>();
                 endpoints.MapControllerRoute("SmidgeComposite", options.Value.UrlOptions.CompositeFilePath + "/{file}", "{controller=Smidge}/{action=Composite}");
-                endpoints.MapControllerRoute("SmidgeBundle", options.Value.UrlOptions.BundleFilePath + "/{file}", "{controller=Smidge}/{action=Bundle}");
+                endpoints.MapControllerRoute("SmidgeBundle", options.Value.UrlOptions.BundleFilePath + "/{bundle}", "{controller=Smidge}/{action=Bundle}");
             });
 #else
             //Create custom route

--- a/src/Smidge/SmidgeStartup.cs
+++ b/src/Smidge/SmidgeStartup.cs
@@ -94,7 +94,7 @@ namespace Smidge
             {
                 var options = app.ApplicationServices.GetRequiredService<IOptions<SmidgeOptions>>();
                 endpoints.MapControllerRoute("SmidgeComposite", options.Value.UrlOptions.CompositeFilePath + "/{file}", "{controller=Smidge}/{action=Composite}");
-                endpoints.MapControllerRoute("SmidgeBundle", options.Value.UrlOptions.CompositeFilePath + "/{file}", "{controller=Smidge}/{action=Bundle}");
+                endpoints.MapControllerRoute("SmidgeBundle", options.Value.UrlOptions.BundleFilePath + "/{file}", "{controller=Smidge}/{action=Bundle}");
             });
 #else
             //Create custom route


### PR DESCRIPTION
Added .net core 3.0 support - types were moved around and required referencing newer versions of the packages. I used the min version that worked (2.1) as netcore 3.0 is still in preview and didn't want to reference the preview packages (which change often). 