### PR TITLE
Fix issue when js files are combined into one file, by changing the delimiter.

### DIFF
--- a/src/Smidge/Controllers/SmidgeController.cs
+++ b/src/Smidge/Controllers/SmidgeController.cs
@@ -212,7 +212,7 @@ namespace Smidge.Controllers
                     .Cast<Stream>()
                     .ToList();
 
-                var delimeter = bundleContext.BundleRequest.Extension == ".js" ? ";" : "\n";
+                var delimeter = bundleContext.BundleRequest.Extension == ".js" ? ";\n" : "\n";
                 var combined = await bundleContext.GetCombinedStreamAsync(inputs, delimeter);
                 return combined;
             }


### PR DESCRIPTION
Fix issue when js files are combined into one file. Use ";\n" as delimiter instead of ";"

Issue occur if the first filestream ends with a commented line like
```
//# sourceMappingURL=angular-local-storage.min.js.map
```
And the first line of the next file is a multi line comment like
```
/*!
 * Chart.js v2.8.0
....
```
The combined file ends up being
```
//# sourceMappingURL=angular-local-storage.min.js.map;/*!
 * Chart.js v2.8.0
```
Where the ` * Chart.js v2.8.0` is invalid syntax.

With this fix the output will be
```
//# sourceMappingURL=angular-local-storage.min.js.map;
/*!
 * Chart.js v2.8.0
```