### PR TITLE
Inform sourcemap generator when a new line is added to minified file.

### DIFF
--- a/src/Smidge.Nuglify/NuglifyJs.cs
+++ b/src/Smidge.Nuglify/NuglifyJs.cs
@@ -91,6 +91,12 @@ namespace Smidge.Nuglify
 
             if (nuglifyJsCodeSettings.SourceMapType != SourceMapType.None)
             {
+                if (codeSettings.SymbolsMap != null)
+                {
+                    // tell the source map we have added a new line to the output (fixes offsets).
+                    codeSettings.SymbolsMap.NewLineInsertedInOutput();
+                }
+
                 AddSourceMapAppenderToContextAsync(fileProcessContext.BundleContext, nuglifyJsCodeSettings.SourceMapType);
             }
 


### PR DESCRIPTION
fix for #106 - tell the source map that we have inserted a newline in the minified file. 

This increments the `lineoffset` and resets the `columoffset` in the source map class, so the that subsequent mappings are offsets are correct when we are processing multiple files. 