### PR TITLE
Refactor how ICacheBuster is used

### DIFF
--- a/src/Smidge.InMemory/ConfiguredCacheFileSystem.cs
+++ b/src/Smidge.InMemory/ConfiguredCacheFileSystem.cs
@@ -41,14 +41,14 @@ namespace Smidge.InMemory
             }
         }
 
-        public Task ClearCachedCompositeFileAsync(ICacheBuster cacheBuster, CompressionType type, string filesetKey)
-            => _wrapped.ClearCachedCompositeFileAsync(cacheBuster, type, filesetKey);
+        public Task ClearCachedCompositeFileAsync(string cacheBusterValue, CompressionType type, string filesetKey)
+            => _wrapped.ClearCachedCompositeFileAsync(cacheBusterValue, type, filesetKey);
 
-        public IFileInfo GetCachedCompositeFile(ICacheBuster cacheBuster, CompressionType type, string filesetKey, out string filePath)
-            => _wrapped.GetCachedCompositeFile(cacheBuster, type, filesetKey, out filePath);
+        public IFileInfo GetCachedCompositeFile(string cacheBusterValue, CompressionType type, string filesetKey, out string filePath)
+            => _wrapped.GetCachedCompositeFile(cacheBusterValue, type, filesetKey, out filePath);
 
-        public IFileInfo GetCacheFile(IWebFile file, Func<IFileInfo> sourceFile, bool fileWatchEnabled, string extension, ICacheBuster cacheBuster, out string filePath)
-            => _wrapped.GetCacheFile(file, sourceFile, fileWatchEnabled, extension, cacheBuster, out filePath);
+        public IFileInfo GetCacheFile(IWebFile file, Func<IFileInfo> sourceFile, bool fileWatchEnabled, string extension, string cacheBusterValue, out string filePath)
+            => _wrapped.GetCacheFile(file, sourceFile, fileWatchEnabled, extension, cacheBusterValue, out filePath);
 
         public IFileInfo GetRequiredFileInfo(string filePath)
             => _wrapped.GetRequiredFileInfo(filePath);

--- a/src/Smidge.InMemory/MemoryCacheFileSystem.cs
+++ b/src/Smidge.InMemory/MemoryCacheFileSystem.cs
@@ -37,12 +37,12 @@ namespace Smidge.InMemory
             return fileInfo;
         }
 
-        private string GetCompositeFilePath(ICacheBuster cacheBuster, CompressionType type, string filesetKey) 
-            => $"{cacheBuster.GetValue()}/{type.ToString()}/{filesetKey + ".s"}";
+        private string GetCompositeFilePath(string cacheBusterValue, CompressionType type, string filesetKey) 
+            => $"{cacheBusterValue}/{type}/{filesetKey + ".s"}";
 
-        public Task ClearCachedCompositeFileAsync(ICacheBuster cacheBuster, CompressionType type, string filesetKey)
+        public Task ClearCachedCompositeFileAsync(string cacheBusterValue, CompressionType type, string filesetKey)
         {
-            var path = GetCompositeFilePath(cacheBuster, type, filesetKey);
+            var path = GetCompositeFilePath(cacheBusterValue, type, filesetKey);
 
             var f = _directory.GetFile(path);
             if (f != null && !f.FileInfo.IsDirectory && f.FileInfo.Exists)
@@ -53,13 +53,13 @@ namespace Smidge.InMemory
             return Task.CompletedTask;
         }
 
-        public IFileInfo GetCachedCompositeFile(ICacheBuster cacheBuster, CompressionType type, string filesetKey, out string filePath)
+        public IFileInfo GetCachedCompositeFile(string cacheBusterValue, CompressionType type, string filesetKey, out string filePath)
         {
-            filePath = GetCompositeFilePath(cacheBuster, type, filesetKey);
+            filePath = GetCompositeFilePath(cacheBusterValue, type, filesetKey);
             return _fileProvider.GetFileInfo(filePath);
         }
 
-        public IFileInfo GetCacheFile(IWebFile file, Func<IFileInfo> sourceFile, bool fileWatchEnabled, string extension, ICacheBuster cacheBuster, out string filePath)
+        public IFileInfo GetCacheFile(IWebFile file, Func<IFileInfo> sourceFile, bool fileWatchEnabled, string extension, string cacheBusterValue, out string filePath)
         {
             IFileInfo cacheFile;
             if (fileWatchEnabled)
@@ -73,14 +73,14 @@ namespace Smidge.InMemory
                 var fileHash = _hasher.GetFileHash(file, string.Empty);
                 var timestampedHash = _hasher.GetFileHash(file, sourceFile(), extension);
 
-                filePath = $"{cacheBuster.GetValue()}/{fileHash}/{timestampedHash}";
+                filePath = $"{cacheBusterValue}/{fileHash}/{timestampedHash}";
                 cacheFile = _fileProvider.GetFileInfo(filePath);
             }
             else
             {
                 var fileHash = _hasher.GetFileHash(file, extension);
 
-                filePath = $"{cacheBuster.GetValue()}/{fileHash}";
+                filePath = $"{cacheBusterValue}/{fileHash}";
                 cacheFile = _fileProvider.GetFileInfo(filePath);
             }
 

--- a/src/Smidge.Nuglify/BundleContextExtensions.cs
+++ b/src/Smidge.Nuglify/BundleContextExtensions.cs
@@ -31,14 +31,14 @@ namespace Smidge.Nuglify
             return inlineSourceMap;
         }
 
-        public static string GetSourceMapFilePath(this BundleContext bundleContext)
+        public static string GetSourceMapFilePath(this BundleContext bundleContext, string cacheBusterValue)
         {
-            return $"{bundleContext.BundleRequest.CacheBuster.GetValue()}/{Path.GetFileName(bundleContext.BundleCompositeFilePath)}.map";
+            return $"{cacheBusterValue}/{Path.GetFileName(bundleContext.BundleCompositeFilePath)}.map";
         }
 
         public static string GetSourceMapFilePath(this BundleRequestModel bundleRequest)
         {
-            return $"{bundleRequest.ParsedPath?.Version ?? bundleRequest.CacheBuster.GetValue()}/{bundleRequest.FileKey}.s.map";
+            return $"{bundleRequest.ParsedPath.CacheBusterValue}/{bundleRequest.FileKey}.s.map";
         }
 
     }

--- a/src/Smidge/Cache/ICacheFileSystem.cs
+++ b/src/Smidge/Cache/ICacheFileSystem.cs
@@ -13,9 +13,9 @@ namespace Smidge.Cache
     public interface ICacheFileSystem
     {
         IFileInfo GetRequiredFileInfo(string filePath);
-        Task ClearCachedCompositeFileAsync(ICacheBuster cacheBuster, CompressionType type, string filesetKey);
-        IFileInfo GetCachedCompositeFile(ICacheBuster cacheBuster, CompressionType type, string filesetKey, out string filePath);
-        IFileInfo GetCacheFile(IWebFile file, Func<IFileInfo> sourceFile, bool fileWatchEnabled, string extension, ICacheBuster cacheBuster, out string filePath);
+        Task ClearCachedCompositeFileAsync(string cacheBusterValue, CompressionType type, string filesetKey);
+        IFileInfo GetCachedCompositeFile(string cacheBusterValue, CompressionType type, string filesetKey, out string filePath);
+        IFileInfo GetCacheFile(IWebFile file, Func<IFileInfo> sourceFile, bool fileWatchEnabled, string extension, string cacheBusterValue, out string filePath);
         Task WriteFileAsync(string filePath, string contents);
         Task WriteFileAsync(string filePath, Stream contents);
     }

--- a/src/Smidge/CompositeFiles/BundleContext.cs
+++ b/src/Smidge/CompositeFiles/BundleContext.cs
@@ -20,17 +20,20 @@ namespace Smidge.CompositeFiles
         /// Creates an empty <see cref="BundleContext"/> which does not track prependers or appenders
         /// </summary>
         /// <returns></returns>
-        public static BundleContext CreateEmpty()
+        public static BundleContext CreateEmpty(string cacheBusterValue)
         {
-            return new BundleContext();
+            return new BundleContext(cacheBusterValue);
         }
 
-        private BundleContext()
+        private BundleContext(string cacheBusterValue)
         {
+            CacheBusterValue = cacheBusterValue;
         }
 
-        public BundleContext(IRequestModel bundleRequest, string bundleCompositeFilePath)
+        public BundleContext(string cacheBusterValue, IRequestModel bundleRequest, string bundleCompositeFilePath)
         {
+            // TODO: Should the cache buster even be on the request model?
+            CacheBusterValue = cacheBusterValue; // BundleRequest.CacheBuster.GetValue();
             BundleRequest = bundleRequest;
             _bundleCompositeFilePath = bundleCompositeFilePath;
         }
@@ -68,6 +71,8 @@ namespace Smidge.CompositeFiles
         public string BundleName => BundleRequest?.FileKey ?? "generated_" + Guid.NewGuid();
 
         public string FileExtension => BundleRequest?.Extension ?? string.Empty;
+
+        public string CacheBusterValue { get; }
 
         public void AddAppender(Func<Task<string>> appender)
         {

--- a/src/Smidge/CompositeFiles/IUrlManager.cs
+++ b/src/Smidge/CompositeFiles/IUrlManager.cs
@@ -1,16 +1,13 @@
 ﻿using Smidge.Models;
-using System;
 using System.Collections.Generic;
-using Microsoft.AspNetCore.Http;
-using Smidge.Cache;
 
 namespace Smidge.CompositeFiles
 {
     public interface IUrlManager
     {
-        string GetUrl(string bundleName, string fileExtension, bool debug, ICacheBuster cacheBuster);
+        string GetUrl(string bundleName, string fileExtension, bool debug, string cacheBusterValue);
 
-        IEnumerable<FileSetUrl> GetUrls(IEnumerable<IWebFile> dependencies, string fileExtension, ICacheBuster cacheBuster);
+        IEnumerable<FileSetUrl> GetUrls(IEnumerable<IWebFile> dependencies, string fileExtension, string cacheBusterValue);
 
         ParsedUrlPath ParsePath(string input);
     }

--- a/src/Smidge/CompositeFiles/ParsedUrlPath.cs
+++ b/src/Smidge/CompositeFiles/ParsedUrlPath.cs
@@ -11,8 +11,13 @@ namespace Smidge.CompositeFiles
     public class ParsedUrlPath
     {
         public WebFileType WebType { get; set; }
+        
         public IEnumerable<string> Names { get; set; }
-        public string Version { get; set; }
+
+        /// <summary>
+        /// The cache buster value used when the URL was generated
+        /// </summary>
+        public string CacheBusterValue { get; set; }
 
         /// <summary>
         /// If the request is in debug mode

--- a/src/Smidge/FileProcessors/PreProcessManager.cs
+++ b/src/Smidge/FileProcessors/PreProcessManager.cs
@@ -68,17 +68,12 @@ namespace Smidge.FileProcessors
 
             var fileWatchEnabled = bundleOptions?.FileWatchOptions.Enabled ?? false;
 
-            var cacheBuster = _cacheBusterResolver.GetCacheBuster(bundleOptions.GetCacheBusterType());
-
-            if (cacheBuster == null)
-            {
-                throw new InvalidOperationException($"No cache buster by type {bundleOptions.GetCacheBusterType()} could be resolved, did you add it to the container?");
-            }
+            var cacheBusterValue = bundleContext.CacheBusterValue;
 
             //we're making this lazy since we don't always want to resolve it
             var sourceFile = new Lazy<IFileInfo>(() => _fileSystem.GetRequiredFileInfo(file), LazyThreadSafetyMode.None);
 
-            var cacheFile = _fileSystem.CacheFileSystem.GetCacheFile(file, () => sourceFile.Value, fileWatchEnabled, extension, cacheBuster, out var filePath);
+            var cacheFile = _fileSystem.CacheFileSystem.GetCacheFile(file, () => sourceFile.Value, fileWatchEnabled, extension, cacheBusterValue, out var filePath);
 
             //check if it's in cache
             if (cacheFile.Exists)

--- a/src/Smidge/Models/BundleRequestModel.cs
+++ b/src/Smidge/Models/BundleRequestModel.cs
@@ -12,7 +12,7 @@ namespace Smidge.Models
     /// </summary>
     public class BundleRequestModel : RequestModel
     {
-        public BundleRequestModel(IUrlManager urlManager, IActionContextAccessor accessor, IRequestHelper requestHelper, IBundleManager bundleManager, CacheBusterResolver cacheBusterResolver)
+        public BundleRequestModel(IUrlManager urlManager, IActionContextAccessor accessor, IRequestHelper requestHelper, IBundleManager bundleManager)
             : base("bundle", urlManager, accessor, requestHelper)
         {
             //TODO: Pretty sure if we want to control the caching of the file, we'll have to retrieve the bundle definition here
@@ -32,11 +32,8 @@ namespace Smidge.Models
                 throw new InvalidOperationException("No bundle found with key " + FileKey);
             }
             Bundle = bundle;
-
-            CacheBuster = cacheBusterResolver.GetCacheBuster(bundle.GetBundleOptions(bundleManager, Debug).GetCacheBusterType());                
         }
 
-        public override ICacheBuster CacheBuster { get; }
         public Bundle Bundle { get; }        
         public override string FileKey { get; }
     }

--- a/src/Smidge/Models/CompositeFileModel.cs
+++ b/src/Smidge/Models/CompositeFileModel.cs
@@ -8,16 +8,13 @@ namespace Smidge.Models
     public class CompositeFileModel : RequestModel
     {
 
-        public CompositeFileModel(IHasher hasher, IUrlManager urlManager, IActionContextAccessor accessor, IRequestHelper requestHelper, IBundleManager bundleManager, CacheBusterResolver cacheBusterResolver)
+        public CompositeFileModel(IHasher hasher, IUrlManager urlManager, IActionContextAccessor accessor, IRequestHelper requestHelper)
             : base("file", urlManager, accessor, requestHelper)
         {
             //Creates a single hash of the full url (which can include many files)
             FileKey = hasher.Hash(string.Join(".", ParsedPath.Names));
-
-            CacheBuster = cacheBusterResolver.GetCacheBuster(bundleManager.GetDefaultBundleOptions(false).GetCacheBusterType());
         }
 
-        public override ICacheBuster CacheBuster { get; }
         public override string FileKey { get; }
     }
 }

--- a/src/Smidge/Models/IRequestModel.cs
+++ b/src/Smidge/Models/IRequestModel.cs
@@ -4,7 +4,6 @@ namespace Smidge.Models
 {
     public interface IRequestModel
     {
-        ICacheBuster CacheBuster { get; }
         CompressionType Compression { get; }
         bool Debug { get; }
         string Extension { get; }

--- a/src/Smidge/Models/RequestModel.cs
+++ b/src/Smidge/Models/RequestModel.cs
@@ -45,11 +45,6 @@ namespace Smidge.Models
         }
 
         /// <summary>
-        /// The cache buster for the current file request
-        /// </summary>
-        public abstract ICacheBuster CacheBuster { get; }
-
-        /// <summary>
         /// The bundle definition name - this is either the bundle name when using named bundles or the composite file
         /// key generated when using composite files
         /// </summary>

--- a/src/Smidge/SmidgeHelper.cs
+++ b/src/Smidge/SmidgeHelper.cs
@@ -201,8 +201,9 @@ namespace Smidge
             }
 
             var cacheBuster = _cacheBusterResolver.GetCacheBuster(bundleOptions.GetCacheBusterType());
-            
-            var url = _urlManager.GetUrl(bundleName, fileExt, debug, cacheBuster);
+            var cacheBusterValue = cacheBuster.GetValue();
+
+            var url = _urlManager.GetUrl(bundleName, fileExt, debug, cacheBusterValue);
             if (!string.IsNullOrWhiteSpace(url))
                 result.Add(url);
 
@@ -238,6 +239,7 @@ namespace Smidge
             var fileBatches = _fileBatcher.GetCompositeFileCollectionForUrlGeneration(orderedFiles);
 
             var cacheBuster = _cacheBusterResolver.GetCacheBuster(_bundleManager.GetDefaultBundleOptions(debug).GetCacheBusterType());
+            var cacheBusterValue = cacheBuster.GetValue();
 
             foreach (var batch in fileBatches)
             {
@@ -254,7 +256,7 @@ namespace Smidge
                     var compositeUrls = _urlManager.GetUrls(
                         batch.Select(x => x.Hashed), 
                         fileType == WebFileType.Css ? ".css" : ".js",
-                        cacheBuster);
+                        cacheBusterValue);
 
                     foreach (var u in compositeUrls)
                     {
@@ -262,10 +264,10 @@ namespace Smidge
 
                         var defaultBundleOptions = _bundleManager.GetDefaultBundleOptions(false);
 
-                        var cacheFile = _fileSystem.CacheFileSystem.GetCachedCompositeFile(cacheBuster, compression, u.Key, out _);
+                        var cacheFile = _fileSystem.CacheFileSystem.GetCachedCompositeFile(cacheBusterValue, compression, u.Key, out _);
                         if (!cacheFile.Exists)
                         {
-                            using (var bundleContext = BundleContext.CreateEmpty())
+                            using (var bundleContext = BundleContext.CreateEmpty(cacheBusterValue))
                             {
                                 //need to process/minify these files - need to use their original paths of course
                                 foreach (var file in batch.Select(x => x.Original))

--- a/src/Smidge/SmidgeStartup.cs
+++ b/src/Smidge/SmidgeStartup.cs
@@ -207,12 +207,13 @@ namespace Smidge
         {
             var bundleOptions = e.File.BundleOptions;
             var cacheBuster = cacheBusterResolver.GetCacheBuster(bundleOptions.GetCacheBusterType());
+            var cacheBusterValue = cacheBuster.GetValue();
 
             //this file is part of this bundle, so the persisted processed/combined/compressed  will need to be 
             // invalidated/deleted/renamed
             foreach (var compressionType in new[] { CompressionType.deflate, CompressionType.gzip, CompressionType.none })
             {
-                await fileSystem.CacheFileSystem.ClearCachedCompositeFileAsync(cacheBuster, compressionType, bundleName);
+                await fileSystem.CacheFileSystem.ClearCachedCompositeFileAsync(cacheBusterValue, compressionType, bundleName);
             }
         }
     }

--- a/test/Smidge.Benchmarks/JsMinifyBenchmarks.cs
+++ b/test/Smidge.Benchmarks/JsMinifyBenchmarks.cs
@@ -135,7 +135,7 @@ namespace Smidge.Benchmarks
 
         public async Task<string> GetJsMin()
         {
-            using (var bc = BundleContext.CreateEmpty())
+            using (var bc = BundleContext.CreateEmpty("1"))
             {
                 var fileProcessContext = new FileProcessContext(JQuery, new JavaScriptFile(), bc);
 
@@ -146,7 +146,7 @@ namespace Smidge.Benchmarks
 
         public async Task<string> GetNuglify()
         {
-            using (var bc = BundleContext.CreateEmpty())
+            using (var bc = BundleContext.CreateEmpty("1"))
             {
                 var fileProcessContext = new FileProcessContext(JQuery, new JavaScriptFile(), bc);
                 await _nuglify.ProcessAsync(fileProcessContext, s => Task.FromResult(0));

--- a/test/Smidge.Tests/CssMinTests.cs
+++ b/test/Smidge.Tests/CssMinTests.cs
@@ -21,7 +21,7 @@ article a:hover {
       color: inherit; }";
 
             var minifier = new CssMinifier();
-            using (var bc = BundleContext.CreateEmpty())
+            using (var bc = BundleContext.CreateEmpty("1"))
             {
                 var fileProcessContext = new FileProcessContext(css, Mock.Of<IWebFile>(), bc);
                 await minifier.ProcessAsync(fileProcessContext, ctx => Task.FromResult(0));
@@ -44,7 +44,7 @@ article a:hover {
 }";
 
             var minifier = new CssMinifier();
-            using (var bc = BundleContext.CreateEmpty())
+            using (var bc = BundleContext.CreateEmpty("1"))
             {
                 var fileProcessContext = new FileProcessContext(cssWithImage, Mock.Of<IWebFile>(), bc);
                 await minifier.ProcessAsync(fileProcessContext, ctx => Task.FromResult(0));
@@ -67,7 +67,7 @@ table {font-family: Arial;   }
 ";
 
             var minifier = new CssMinifier();
-            using (var bc = BundleContext.CreateEmpty())
+            using (var bc = BundleContext.CreateEmpty("1"))
             {
                 var fileProcessContext = new FileProcessContext(css, Mock.Of<IWebFile>(), bc);
                 await minifier.ProcessAsync(fileProcessContext, ctx => Task.FromResult(0));
@@ -123,7 +123,7 @@ audio:not([controls]) {
 }";
 
             var minifier = new CssMinifier();
-            using (var bc = BundleContext.CreateEmpty())
+            using (var bc = BundleContext.CreateEmpty("1"))
             {
                 var fileProcessContext = new FileProcessContext(css, Mock.Of<IWebFile>(), bc);
                 await minifier.ProcessAsync(fileProcessContext, ctx => Task.FromResult(0));

--- a/test/Smidge.Tests/DefaultUrlManagerTests.cs
+++ b/test/Smidge.Tests/DefaultUrlManagerTests.cs
@@ -29,7 +29,7 @@ namespace Smidge.Tests
 
             var result = manager.ParsePath(path);
 
-            Assert.Equal("1", result.Version);
+            Assert.Equal("1", result.CacheBusterValue);
             Assert.Equal(4, result.Names.Count());
             Assert.Equal(WebFileType.Js, result.WebType);
         }
@@ -50,7 +50,7 @@ namespace Smidge.Tests
                 hasher.Object,
                 urlHelper);
 
-            var url = creator.GetUrl("my-bundle", ".js", false, Mock.Of<ICacheBuster>(buster => buster.GetValue() == "1"));
+            var url = creator.GetUrl("my-bundle", ".js", false, "1");
 
             Assert.Equal("/sg/my-bundle.js.v1", url);
         }
@@ -72,8 +72,7 @@ namespace Smidge.Tests
                 urlHelper);
 
             var url = creator.GetUrls(
-                new List<IWebFile> { new JavaScriptFile("Test1.js"), new JavaScriptFile("Test2.js") }, ".js",
-                Mock.Of<ICacheBuster>(buster => buster.GetValue() == "1"));
+                new List<IWebFile> { new JavaScriptFile("Test1.js"), new JavaScriptFile("Test2.js") }, ".js", "1");
 
             Assert.Single(url);
             Assert.Equal("/sg/Test1.Test2.js.v1", url.First().Url);
@@ -97,8 +96,7 @@ namespace Smidge.Tests
                 urlHelper);
 
             var url = creator.GetUrls(
-                new List<IWebFile> { new JavaScriptFile("Test1.js"), new JavaScriptFile("Test2.js") }, ".js",
-                Mock.Of<ICacheBuster>(buster => buster.GetValue() == "1"));
+                new List<IWebFile> { new JavaScriptFile("Test1.js"), new JavaScriptFile("Test2.js") }, ".js", "1");
 
             Assert.Equal(2, url.Count());
             Assert.Equal("/sg/Test1.js.v1", url.ElementAt(0).Url);
@@ -124,8 +122,7 @@ namespace Smidge.Tests
                 urlHelper);
 
             Assert.Throws<InvalidOperationException>(() => creator.GetUrls(
-                new List<IWebFile> { new JavaScriptFile("Test1.js") }, ".js",
-                Mock.Of<ICacheBuster>(buster => buster.GetValue() == "1")));
+                new List<IWebFile> { new JavaScriptFile("Test1.js") }, ".js", "1"));
 
         }
     }

--- a/test/Smidge.Tests/JsSourceMapProcessorTests.cs
+++ b/test/Smidge.Tests/JsSourceMapProcessorTests.cs
@@ -22,7 +22,7 @@ namespace Smidge.Tests
  asdf asdf asd fasdf";
 
             var removeMaps = GetJsSourceMapProcessor();
-            using (var bc = BundleContext.CreateEmpty())
+            using (var bc = BundleContext.CreateEmpty("1"))
             {
                 var fileProcessContext = new FileProcessContext(js, new JavaScriptFile("js/test.js"), bc);
                 await removeMaps.ProcessAsync(fileProcessContext, ctx => Task.FromResult(0));

--- a/test/Smidge.Tests/PreProcessorPipelineTests.cs
+++ b/test/Smidge.Tests/PreProcessorPipelineTests.cs
@@ -22,7 +22,7 @@ namespace Smidge.Tests
                 new ProcessorHeader(), 
                 new ProcessorFooter()
             });
-            using (var bc = BundleContext.CreateEmpty())
+            using (var bc = BundleContext.CreateEmpty("1"))
             {
                 var result = await pipeline.ProcessAsync(new FileProcessContext("This is some content", Mock.Of<IWebFile>(), bc));
 


### PR DESCRIPTION
This is part of the conversation for #108 

One main issue is that ICacheBuster used to have a known value at least per appdomain but that is not the case if we are using a timestamped one. This means we cannot rely on the ICacheBuster.GetValue to return a consistent value per bundle. But this leads the code into a better place since really the cache buster should only be used to create the URL, not when receiving the URL (since the cache buster value already exists in the URL and can be parsed). 

So this refactors when ICacheBuster.GetValue() is called and we no longer pass around ICacheBuster, instead we just pass in the `string` cache buster value where required. ,ICacheBuster.GetValue() is only called for creating URLs. 

This renames ParsedUrlPath.Version to ParsedUrlPath.CacheBusterValue since that's what it is and its much clearer. And now ParsedUrlPath.CacheBusterValue is used wherever we need the cache buster value from a received bundle request (instead of relying on ICacheBuster.GetValue to return the same value).

This leads to being able to remove a bunch of dependencies on things like RequestModel (and sub classes) and actually simplifies a bunch of code. 