### PR TITLE
Makes the Smidge <link> tag helper allow <link rel="" > or <link rel="" />

### DIFF
--- a/src/Smidge/TagHelpers/SmidgeLinkTagHelper.cs
+++ b/src/Smidge/TagHelpers/SmidgeLinkTagHelper.cs
@@ -9,7 +9,7 @@ using Microsoft.AspNetCore.Mvc.TagHelpers;
 
 namespace Smidge.TagHelpers
 {
-    [HtmlTargetElement("link", Attributes = "href")]
+    [HtmlTargetElement("link", Attributes = "href", TagStructure = TagStructure.WithoutEndTag)]
     public class SmidgeLinkTagHelper : TagHelper
     {
         private readonly SmidgeHelper _smidgeHelper;


### PR DESCRIPTION
When I added the taghelper to my _viewimports.cshtml I got some errors because the template I was using included CSS without the self close `/>`

So I have done this change so it will be nice that by having or adding the Smidge TagHelper I don't get errors straight away for CSS  such as...

```html
<link href="https://cdn.jsdelivr.net/npm/bootstrap@@5.1.0/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-KyZXEAg3QhqLMpG8r+8fhAXLRk2vvoC2f3B09zVXn8CA5QIVfZOJ3BCsw2P0p/We" crossorigin="anonymous" >
```