### PR TITLE
Add Brotli support

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -21,5 +21,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <VersionPrefix>4.0.0</VersionPrefix>
   </PropertyGroup>
-
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+  </PropertyGroup>
 </Project>

--- a/src/Smidge.Core/CompositeFiles/Compressor.cs
+++ b/src/Smidge.Core/CompositeFiles/Compressor.cs
@@ -17,16 +17,20 @@ namespace Smidge.CompositeFiles
             {
                 Stream compressedStream = null;
 
-                if (type == CompressionType.deflate)
+                if (type == CompressionType.Deflate)
                 {
-                    compressedStream = new DeflateStream(ms, CompressionMode.Compress);
+                    compressedStream = new DeflateStream(ms, CompressionLevel.Optimal);
                 }
-                else if (type == CompressionType.gzip)
+                else if (type == CompressionType.GZip)
                 {
-                    compressedStream = new GZipStream(ms, CompressionMode.Compress);
+                    compressedStream = new GZipStream(ms, CompressionLevel.Optimal);
+                }
+                else if (type == CompressionType.Brotli)
+                {
+                    compressedStream = new BrotliStream(ms, CompressionLevel.Optimal);
                 }
 
-                if (type != CompressionType.none)
+                if (type != CompressionType.None)
                 {
                     using (compressedStream)
                     {
@@ -46,6 +50,4 @@ namespace Smidge.CompositeFiles
             }
         }
     }
-
-    
 }

--- a/src/Smidge.Core/CompressionType.cs
+++ b/src/Smidge.Core/CompressionType.cs
@@ -4,6 +4,9 @@ namespace Smidge
 {
     public enum CompressionType
     {
-        deflate, gzip, none
+        Deflate, 
+        GZip, 
+        Brotli, 
+        None
     }
 }

--- a/src/Smidge.Core/Smidge.Core.csproj
+++ b/src/Smidge.Core/Smidge.Core.csproj
@@ -10,9 +10,6 @@
     <StartupObject />
     <IsPackable>true</IsPackable>
   </PropertyGroup>
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-  </PropertyGroup>
   <ItemGroup>
     <Content Include="..\..\assets\logo-nuget.png" Link="logo-nuget.png" Pack="true" PackagePath="" />
   </ItemGroup>

--- a/src/Smidge.InMemory/Smidge.InMemory.csproj
+++ b/src/Smidge.InMemory/Smidge.InMemory.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <AssemblyTitle>Smidge.InMemory</AssemblyTitle>
     <Description>An in-memory caching provider for Smidge</Description>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <AssemblyName>Smidge.InMemory</AssemblyName>
     <PackageId>Smidge.InMemory</PackageId>
     <PackageTags>css;javascript;minify;compression;combination;aspnetcore</PackageTags>

--- a/src/Smidge.Nuglify/Smidge.Nuglify.csproj
+++ b/src/Smidge.Nuglify/Smidge.Nuglify.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <AssemblyTitle>Smidge.Nuglify</AssemblyTitle>
     <Description>A Nuglify engine for Smidge</Description>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
     <AssemblyName>Smidge.Nuglify</AssemblyName>
     <PackageId>Smidge.Nuglify</PackageId>
     <PackageTags>css;javascript;minify;compression;combination;nuglify;uglify;aspnetcore</PackageTags>

--- a/src/Smidge.Web/Smidge.Web.csproj
+++ b/src/Smidge.Web/Smidge.Web.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <AssemblyName>Smidge.Web</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/src/Smidge/Controllers/SmidgeController.cs
+++ b/src/Smidge/Controllers/SmidgeController.cs
@@ -135,7 +135,7 @@ namespace Smidge.Controllers
                     //compress the response (if enabled)
                     var compressedStream = await Compressor.CompressAsync(
                         //do not compress anything if it's not enabled in the bundle options
-                        bundleOptions.CompressResult ? bundleModel.Compression : CompressionType.none,
+                        bundleOptions.CompressResult ? bundleModel.Compression : CompressionType.None,
                         resultStream);
 
                     //save the resulting compressed file, if compression is not enabled it will just save the non compressed format

--- a/src/Smidge/HttpExtensions.cs
+++ b/src/Smidge/HttpExtensions.cs
@@ -22,8 +22,7 @@ namespace Smidge
             {
                 foreach (var segment in ifNoneMatch)
                 {
-                    if (segment.Equals("*", StringComparison.Ordinal)
-                        || segment.Equals(etag, StringComparison.Ordinal))
+                    if (segment.Equals("*", StringComparison.Ordinal) || segment.Equals(etag, StringComparison.Ordinal))
                     {
                         return false;
                     }
@@ -71,8 +70,7 @@ namespace Smidge
 
         public static void AddCacheControlResponseHeader(this HttpResponse response, int cacheHours = 10)
         {
-            response.Headers[HttpConstants.CacheControl] = string.Format("public, max-age={0}, s-maxage={0}",
-                TimeSpan.FromHours(cacheHours) .TotalSeconds);
+            response.Headers[HttpConstants.CacheControl] = string.Format("public, max-age={0}, s-maxage={0}", TimeSpan.FromHours(cacheHours) .TotalSeconds);
         }
 
         public static void AddETagResponseHeader(this HttpResponse response, string etag)
@@ -82,15 +80,26 @@ namespace Smidge
 
         public static void AddCompressionResponseHeader(this HttpResponse response, CompressionType cType)
         {
-            if (cType == CompressionType.deflate)
+            switch (cType)
             {
-                response.Headers[HttpConstants.ContentEncoding] = "deflate";
-                response.Headers[HttpConstants.Vary] = HttpConstants.AcceptEncoding;
-            }
-            else if (cType == CompressionType.gzip)
-            {
-                response.Headers[HttpConstants.ContentEncoding] = "gzip";
-                response.Headers[HttpConstants.Vary] = HttpConstants.AcceptEncoding;
+                case CompressionType.Brotli:
+                {
+                    response.Headers[HttpConstants.ContentEncoding] = "br";
+                    response.Headers[HttpConstants.Vary] = HttpConstants.AcceptEncoding;
+                    break;
+                }
+                case CompressionType.GZip:
+                {
+                    response.Headers[HttpConstants.ContentEncoding] = "gzip";
+                    response.Headers[HttpConstants.Vary] = HttpConstants.AcceptEncoding;
+                    break;
+                }
+                case CompressionType.Deflate:
+                {
+                    response.Headers[HttpConstants.ContentEncoding] = "deflate";
+                    response.Headers[HttpConstants.Vary] = HttpConstants.AcceptEncoding;
+                    break;
+                }
             }
         }
     }

--- a/src/Smidge/Smidge.csproj
+++ b/src/Smidge/Smidge.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <AssemblyTitle>Smidge</AssemblyTitle>
     <Description>A lightweight library for runtime CSS and JavaScript file management, minification, combination &amp; compression</Description>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
     <AssemblyName>Smidge</AssemblyName>
     <PackageId>Smidge</PackageId>
     <PackageTags>css;javascript;minify;compression;combination;aspnetcore</PackageTags>

--- a/src/Smidge/SmidgeStartup.cs
+++ b/src/Smidge/SmidgeStartup.cs
@@ -195,7 +195,7 @@ namespace Smidge
 
             //this file is part of this bundle, so the persisted processed/combined/compressed  will need to be 
             // invalidated/deleted/renamed
-            foreach (var compressionType in new[] { CompressionType.deflate, CompressionType.gzip, CompressionType.none })
+            foreach (var compressionType in new[] { CompressionType.Brotli, CompressionType.GZip, CompressionType.Deflate, CompressionType.None })
             {
                 await fileSystem.CacheFileSystem.ClearCachedCompositeFileAsync(cacheBusterValue, compressionType, bundleName);
             }


### PR DESCRIPTION
Also unified all target frameworks in Directory.Build.props as Brotli requires .NET Core 2.1+.