### PR TITLE
Fix dynamically registered external files adding / before URL

### DIFF
--- a/src/Smidge.Core/SmidgeFileSystem.cs
+++ b/src/Smidge.Core/SmidgeFileSystem.cs
@@ -65,6 +65,9 @@ namespace Smidge
         /// <inheritdoc />
         public IEnumerable<string> GetMatchingFiles(string filePattern)
         {
+            if (filePattern.Contains(SmidgeConstants.SchemeDelimiter))
+                return new []{ filePattern };
+
             var ext = Path.GetExtension(filePattern);
             if (string.IsNullOrWhiteSpace(ext))
             {

--- a/test/Smidge.Tests/BundleFileSetGeneratorTests.cs
+++ b/test/Smidge.Tests/BundleFileSetGeneratorTests.cs
@@ -48,6 +48,37 @@ namespace Smidge.Tests
         }
 
         [Fact]
+        public void Get_Ordered_File_External_Set()
+        {
+            var websiteInfo = new Mock<IWebsiteInfo>();
+            websiteInfo.Setup(x => x.GetBasePath()).Returns(string.Empty);
+            websiteInfo.Setup(x => x.GetBaseUrl()).Returns(new Uri("http://test.com"));
+
+            var urlHelper = new RequestHelper(websiteInfo.Object);
+
+            var fileProvider = new Mock<IFileProvider>();
+            var cacheProvider = new Mock<ICacheFileSystem>();
+            var fileProviderFilter = new DefaultFileProviderFilter();
+
+            var fileSystemHelper = new SmidgeFileSystem(fileProvider.Object, fileProviderFilter, cacheProvider.Object, Mock.Of<IWebsiteInfo>());
+            var pipeline = new PreProcessPipeline(Enumerable.Empty<IPreProcessor>());
+            var smidgeOptions = new Mock<IOptions<SmidgeOptions>>();
+            smidgeOptions.Setup(opt => opt.Value).Returns(new SmidgeOptions());
+
+            var generator = new BundleFileSetGenerator(fileSystemHelper,
+                                                       new FileProcessingConventions(smidgeOptions.Object, Enumerable.Empty<IFileProcessingConvention>()));
+
+            var result = generator.GetOrderedFileSet(new IWebFile[] {
+                Mock.Of<IWebFile>(f => f.FilePath == "http://test-site.com/test.js"),
+                Mock.Of<IWebFile>(f => f.FilePath == "https://external-site.com/external.js")
+            }, pipeline);
+
+            Assert.Equal(2, result.Count());
+            Assert.Equal("http://test-site.com/test.js", result.ElementAt(0).FilePath);
+            Assert.Equal("https://external-site.com/external.js", result.ElementAt(1).FilePath);
+        }
+
+        [Fact]
         public void Get_Ordered_File_Set_Correct_Order()
         {
             var websiteInfo = new Mock<IWebsiteInfo>();


### PR DESCRIPTION
With the current code all external dynamic URLs get a / added before the URL.