### PR TITLE
Disable MakePathsRelative when generating SourceMaps

### DIFF
--- a/src/Smidge.Nuglify/V3DeferedSourceMap.cs
+++ b/src/Smidge.Nuglify/V3DeferedSourceMap.cs
@@ -11,10 +11,10 @@ namespace Smidge.Nuglify
     /// </summary>
     /// <remarks>
     /// Typically the standard V3SourceMap requires that you provide it a list of files to proces up-front and it will return a single source map
-    /// for them all, however we don't have the ability to tell a single instance up-front which files to process we just know the files when we 
-    /// start processing them. Luckily the underlying V3SourceMap can work with this since anytime Nuglify processes a JS file it will update the 
-    /// underlying V3SourceMap document with a new source and append to it's sources list. 
-    /// 
+    /// for them all, however we don't have the ability to tell a single instance up-front which files to process we just know the files when we
+    /// start processing them. Luckily the underlying V3SourceMap can work with this since anytime Nuglify processes a JS file it will update the
+    /// underlying V3SourceMap document with a new source and append to it's sources list.
+    ///
     /// So this is deferred because it does not write to the processed JS file, it defers the output and writes to a string builder which can be retrieved later.
     /// </remarks>
     public class V3DeferredSourceMap : ISourceMap
@@ -24,20 +24,22 @@ namespace Smidge.Nuglify
         public SourceMapType SourceMapType { get; }
 
         private readonly V3SourceMap _wrapped;
-        private readonly StringBuilder _mapBuilder;        
+        private readonly StringBuilder _mapBuilder;
         private string _mapPath;
 
         /// <summary>
         /// Creates a new inline source map
         /// </summary>
         /// <param name="wrapped"></param>
-        /// <param name="mapBuilder"></param>        
+        /// <param name="mapBuilder"></param>
         /// <param name="sourceSourceMapType"></param>
         public V3DeferredSourceMap(V3SourceMap wrapped, StringBuilder mapBuilder, SourceMapType sourceSourceMapType)
         {
             _wrapped = wrapped ?? throw new ArgumentNullException(nameof(wrapped));
             _mapBuilder = mapBuilder ?? throw new ArgumentNullException(nameof(mapBuilder));
             SourceMapType = sourceSourceMapType;
+            // Disable relative paths, this will always fail and make source maps super slow.
+            _wrapped.MakePathsRelative = false;
         }
 
         public void Dispose()


### PR DESCRIPTION
We got a bug report over on the Umbraco repo about some javascript assets loading super slowly, in testing I managed to hit 10 second load times reliably. A community member did some great digging and found that the cause of it is when the source maps are generated in [this comment](https://github.com/umbraco/Umbraco-CMS/issues/10252#issuecomment-843666121).

It fails in Nuglify because it will try and make the path relative, even though it's already relative, leading to an exception being thrown for every segment it tries to process making it super slow.

This PR disables the feature making paths relative in Nuglify across the board since as far as I've been able to gather the paths will always be relative when using Smidge, so it shouldn't be needed. If it's not the case and the feature needs to be enabled in certain scenarios it should of course be configurable instead.

After disabling `MakePathsRelative` the time improved from 9-10 seconds down to less than one second. 