### PR TITLE
Named Profiles for option configuration

### DIFF
--- a/src/Smidge.Core/DefaultProfileStrategy.cs
+++ b/src/Smidge.Core/DefaultProfileStrategy.cs
@@ -1,0 +1,14 @@
+using Smidge.Options;
+
+namespace Smidge
+{
+
+    /// <summary>
+    /// An implementation of ISmidgeProfileStrategy that will always use the Default profile.
+    /// </summary>
+    /// <seealso cref="ISmidgeProfileStrategy" />
+    public class DefaultProfileStrategy : ISmidgeProfileStrategy
+    {
+        public string GetCurrentProfileName() => SmidgeOptionsProfile.Default;
+    }
+}

--- a/src/Smidge.Core/FileProcessors/PreProcessManager.cs
+++ b/src/Smidge.Core/FileProcessors/PreProcessManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.IO;
 using System.Threading;
@@ -34,7 +34,7 @@ namespace Smidge.FileProcessors
             if (file == null) throw new ArgumentNullException(nameof(file));
             if (file.Pipeline == null) throw new ArgumentNullException($"{nameof(file)}.Pipeline");
 
-            await ProcessFile(file, _bundleManager.GetAvailableOrDefaultBundleOptions(bundleOptions, false), bundleContext);
+            await ProcessFile(file, _bundleManager.GetAvailableOrDefaultBundleOptions(bundleOptions), bundleContext);
         }
 
         private async Task ProcessFile(IWebFile file, BundleOptions bundleOptions, BundleContext bundleContext)

--- a/src/Smidge.Core/FileProcessors/PreProcessPipelineFactory.cs
+++ b/src/Smidge.Core/FileProcessors/PreProcessPipelineFactory.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Smidge.Models;
 using System.Linq;
@@ -67,19 +67,20 @@ namespace Smidge.FileProcessors
                 switch (fileType)
                 {
                     case WebFileType.Js:
+
                         return new PreProcessPipeline(new IPreProcessor[]
                         {
-                            _allProcessors.Value.OfType<JsMinifier>().First(),
-                            _allProcessors.Value.OfType<JsSourceMapProcessor>().First()
-                        });
+                            _allProcessors.Value.OfType<JsMinifier>().FirstOrDefault(),
+                            _allProcessors.Value.OfType<JsSourceMapProcessor>().FirstOrDefault()
+                        }.Where(p => p != null));
                     case WebFileType.Css:
                     default:
                         return new PreProcessPipeline(new IPreProcessor[]
                         {
-                            _allProcessors.Value.OfType<CssImportProcessor>().First(),
-                            _allProcessors.Value.OfType<CssUrlProcessor>().First(),
-                            _allProcessors.Value.OfType<CssMinifier>().First()
-                        });
+                            _allProcessors.Value.OfType<CssImportProcessor>().FirstOrDefault(),
+                            _allProcessors.Value.OfType<CssUrlProcessor>().FirstOrDefault(),
+                            _allProcessors.Value.OfType<CssMinifier>().FirstOrDefault()
+                        }.Where(p => p != null));
                 }
             });
         }

--- a/src/Smidge.Core/HostEnvironmentProfileStrategy.cs
+++ b/src/Smidge.Core/HostEnvironmentProfileStrategy.cs
@@ -1,0 +1,33 @@
+using Microsoft.Extensions.Hosting;
+using Smidge.Options;
+
+namespace Smidge
+{
+    /// <summary>
+    /// An implementation of ISmidgeProfileStrategy that will use the host environment to determine if the Debug profile should be used.
+    /// </summary>
+    /// <seealso cref="ISmidgeProfileStrategy" />
+    public class HostEnvironmentProfileStrategy : ISmidgeProfileStrategy
+    {
+        private readonly IHostEnvironment _hostEnvironment;
+
+
+        public HostEnvironmentProfileStrategy(IHostEnvironment hostEnvironment)
+        {
+            _hostEnvironment = hostEnvironment;
+        }
+
+
+        private string _profileName;
+
+        public string GetCurrentProfileName() => _profileName ??= GetProfileForEnvironment(_hostEnvironment);
+        
+
+        protected virtual string GetProfileForEnvironment(IHostEnvironment hostEnvironment)
+        {
+            return hostEnvironment.IsDevelopment()
+                ? SmidgeOptionsProfile.Debug
+                : SmidgeOptionsProfile.Default;
+        }
+    }
+}

--- a/src/Smidge.Core/ISmidgeProfileStrategy.cs
+++ b/src/Smidge.Core/ISmidgeProfileStrategy.cs
@@ -1,0 +1,12 @@
+
+namespace Smidge
+{
+
+    /// <summary>
+    /// An interface that returns the name of an options profile to use for the current request.
+    /// </summary>
+    public interface ISmidgeProfileStrategy
+    {
+        string GetCurrentProfileName();
+    }
+}

--- a/src/Smidge.Core/Models/Bundle.cs
+++ b/src/Smidge.Core/Models/Bundle.cs
@@ -45,10 +45,30 @@ namespace Smidge.Models
         /// </summary>
         public Func<IEnumerable<IWebFile>, IEnumerable<IWebFile>> OrderingCallback { get; private set; }
 
+
+
+        /// <summary>
+        /// The name of the Profile used to configure the BundleOptions for this bundle.
+        /// If a BundleOptions has also been specified, the ProfileName will have no effect.
+        /// </summary>
+        public string ProfileName { get; set; }
+
+        /// <summary>
+        /// Set the name of the Profile to use for this bundle.
+        /// </summary>
+        /// <param name="profileName">Name of the profile.</param>
+        public Bundle UseProfile(string profileName)
+        {
+            ProfileName = profileName;
+            return this;
+        }
+
+
+
         /// <summary>
         /// Defines the options for this bundle
         /// </summary>
-        public BundleEnvironmentOptions BundleOptions { get; private set; }        
+        public BundleEnvironmentOptions BundleOptions { get; private set; }
 
         /// <summary>
         /// Sets the options for the bundle

--- a/src/Smidge.Core/Models/BundleExtensions.cs
+++ b/src/Smidge.Core/Models/BundleExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Smidge.Options;
+using System;
+using Smidge.Options;
 
 namespace Smidge.Models
 {
@@ -11,14 +12,34 @@ namespace Smidge.Models
         /// <param name="bundleMgr"></param>
         /// <param name="debug"></param>
         /// <returns></returns>
+        [Obsolete("Use GetBundleOptions(IBundleManager, string) and specify a configuration profile name.")]
         public static BundleOptions GetBundleOptions(this Bundle bundle, IBundleManager bundleMgr, bool debug)
         {
             var bundleOptions = debug
-                ? (bundle.BundleOptions == null ? bundleMgr.DefaultBundleOptions.DebugOptions : bundle.BundleOptions.DebugOptions)
-                : (bundle.BundleOptions == null ? bundleMgr.DefaultBundleOptions.ProductionOptions : bundle.BundleOptions.ProductionOptions);
+                ? GetBundleOptions(bundle, bundleMgr, SmidgeOptionsProfile.Debug)
+                : GetBundleOptions(bundle, bundleMgr, SmidgeOptionsProfile.Default);
 
             return bundleOptions;
         }
+        
+        /// <summary>
+        /// Get the bundle options from the bundle if they have been set otherwise with the defaults
+        /// </summary>
+        /// <param name="bundle"></param>
+        /// <param name="bundleMgr"></param>
+        /// <param name="profileName"></param>
+        /// <returns></returns>
+        public static BundleOptions GetBundleOptions(this Bundle bundle, IBundleManager bundleMgr, string profileName)
+        {
+            var bundleOptions = bundle.BundleOptions == null
+                ? bundleMgr.DefaultBundleOptions[profileName]
+                : bundle.BundleOptions[profileName];
+
+            return bundleOptions;
+        }
+
+
+
 
         /// <summary>
         /// Gets the default bundle options based on whether we're in debug or not
@@ -26,6 +47,7 @@ namespace Smidge.Models
         /// <param name="bundleMgr"></param>
         /// <param name="debug"></param>
         /// <returns></returns>
+        [Obsolete("Use GetDefaultBundleOptions(IBundleManager, string) and specify a configuration profile name.")]
         public static BundleOptions GetDefaultBundleOptions(this IBundleManager bundleMgr, bool debug)
         {
             var bundleOptions = debug
@@ -35,11 +57,38 @@ namespace Smidge.Models
             return bundleOptions;
         }
 
+
+        /// <summary>
+        /// Gets the default bundle options for a particular configuration profile.
+        /// </summary>
+        /// <param name="bundleMgr"></param>
+        /// <param name="profileName">The name of a configuration profile.</param>
+        /// <returns></returns>
+        public static BundleOptions GetDefaultBundleOptions(this IBundleManager bundleMgr, string profileName)
+        {
+            var bundleOptions = bundleMgr.DefaultBundleOptions[profileName];
+
+            return bundleOptions;
+        }
+
+
+
+
+
+        [Obsolete("Use GetAvailableOrDefaultBundleOptions(BundleOptions, string) and specify a configuration profile name.")]
         public static BundleOptions GetAvailableOrDefaultBundleOptions(this IBundleManager bundleMgr, BundleOptions options, bool debug)
+        {
+            return GetAvailableOrDefaultBundleOptions(bundleMgr, options, debug ? SmidgeOptionsProfile.Debug : SmidgeOptionsProfile.Default);
+        }
+
+
+        public static BundleOptions GetAvailableOrDefaultBundleOptions(this IBundleManager bundleMgr, BundleOptions options, string profileName)
         {
             return options != null
                 ? options
-                : bundleMgr.GetDefaultBundleOptions(debug);
+                : bundleMgr.GetDefaultBundleOptions(profileName);
         }
+
+
     }
 }

--- a/src/Smidge.Core/Models/BundleExtensions.cs
+++ b/src/Smidge.Core/Models/BundleExtensions.cs
@@ -82,6 +82,11 @@ namespace Smidge.Models
         }
 
 
+        public static BundleOptions GetAvailableOrDefaultBundleOptions(this IBundleManager bundleMgr, BundleOptions options)
+        {
+            return GetAvailableOrDefaultBundleOptions(bundleMgr, options, SmidgeOptionsProfile.Default);
+        }
+
         public static BundleOptions GetAvailableOrDefaultBundleOptions(this IBundleManager bundleMgr, BundleOptions options, string profileName)
         {
             return options != null

--- a/src/Smidge.Core/Options/BundleEnvironmentOptions.cs
+++ b/src/Smidge.Core/Options/BundleEnvironmentOptions.cs
@@ -68,6 +68,7 @@ namespace Smidge.Options
 
         /// <summary>
         /// Gets or sets the <see cref="BundleOptions"/> for the specified profile.
+        /// If the profile has not been previously configured, returns a new <see cref="BundleOptions"/> instance.
         /// </summary>
         /// <param name="profileName">Name of the profile.</param>
         /// <returns></returns>
@@ -75,7 +76,7 @@ namespace Smidge.Options
         {
             get
             {
-                if (!_profileOptions.TryGetValue(profileName, out BundleOptions options))
+                if (!TryGetProfileOptions(profileName, out BundleOptions options))
                 {
                     // Initialise a new BundleOptions for the requested profile
                     options = new BundleOptions();
@@ -87,6 +88,17 @@ namespace Smidge.Options
             set => _profileOptions[profileName] = value;
         }
 
+
+        /// <summary>
+        /// Gets the <see cref="BundleOptions"/> for the specified profile, if the profile has previously been configured.
+        /// </summary>
+        /// <param name="profileName">Name of the profile.</param>
+        /// <param name="options">The profile options.</param>
+        /// <returns></returns>
+        public bool TryGetProfileOptions(string profileName, out BundleOptions options)
+        {
+            return _profileOptions.TryGetValue(profileName, out options);
+        }
 
     }
 }

--- a/src/Smidge.Core/Options/BundleEnvironmentOptions.cs
+++ b/src/Smidge.Core/Options/BundleEnvironmentOptions.cs
@@ -66,7 +66,11 @@ namespace Smidge.Options
 
 
 
-
+        /// <summary>
+        /// Gets or sets the <see cref="BundleOptions"/> for the specified profile.
+        /// </summary>
+        /// <param name="profileName">Name of the profile.</param>
+        /// <returns></returns>
         public BundleOptions this[string profileName]
         {
             get

--- a/src/Smidge.Core/Options/BundleEnvironmentOptions.cs
+++ b/src/Smidge.Core/Options/BundleEnvironmentOptions.cs
@@ -1,12 +1,12 @@
-﻿using System;
-using Smidge.Cache;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
 
 namespace Smidge.Options
 {
 
 
     /// <summary>
-    /// Defines the different bundle options for Debug vs Production
+    /// Defines the different bundle options for various configuration profiles such as Debug or Production
     /// </summary>
     public sealed class BundleEnvironmentOptions
     {
@@ -20,14 +20,21 @@ namespace Smidge.Options
             return new BundleEnvironmentOptionsBuilder(options);
         }
 
+
+
+        private readonly IDictionary<string, BundleOptions> _profileOptions;
+
+
         /// <summary>
         /// Constructor, sets default options
         /// </summary>
         public BundleEnvironmentOptions()
         {
+            _profileOptions = new ConcurrentDictionary<string, BundleOptions>();
+
             DebugOptions = new BundleOptions
             {
-                
+
                 ProcessAsCompositeFile = false,
                 CompressResult = false,
                 CacheControlOptions = new CacheControlOptions
@@ -36,17 +43,46 @@ namespace Smidge.Options
                     CacheControlMaxAge = 0
                 }
             };
-            ProductionOptions = new BundleOptions();    
+            ProductionOptions = new BundleOptions();
         }
-        
-        /// <summary>
-        /// The options for debug mode
-        /// </summary>
-        public BundleOptions DebugOptions { get; set; }
 
         /// <summary>
-        /// The options for production mode
+        /// The options for the "debug" profile
         /// </summary>
-        public BundleOptions ProductionOptions { get; set; }
+        public BundleOptions DebugOptions
+        {
+            get => this[SmidgeOptionsProfile.Debug];
+            set => this[SmidgeOptionsProfile.Debug] = value;
+        }
+
+        /// <summary>
+        /// The options for "production" profile
+        /// </summary>
+        public BundleOptions ProductionOptions
+        {
+            get => this[SmidgeOptionsProfile.Production];
+            set => this[SmidgeOptionsProfile.Production] = value;
+        }
+
+
+
+
+        public BundleOptions this[string profileName]
+        {
+            get
+            {
+                if (!_profileOptions.TryGetValue(profileName, out BundleOptions options))
+                {
+                    // Initialise a new BundleOptions for the requested profile
+                    options = new BundleOptions();
+                    _profileOptions.Add(profileName, options);
+                }
+
+                return options;
+            }
+            set => _profileOptions[profileName] = value;
+        }
+
+
     }
 }

--- a/src/Smidge.Core/Options/SmidgeOptionsProfile.cs
+++ b/src/Smidge.Core/Options/SmidgeOptionsProfile.cs
@@ -1,0 +1,11 @@
+
+namespace Smidge.Options
+{
+    public static class SmidgeOptionsProfile
+    {
+        public const string Default = Production;
+
+        public const string Debug = "Debug";
+        public const string Production = "Production";
+    }
+}

--- a/src/Smidge.Web/Views/Home/Index.cshtml
+++ b/src/Smidge.Web/Views/Home/Index.cshtml
@@ -38,12 +38,12 @@
 <body>
 
     @await Html.PartialAsync("TopBar")
-    @await Html.PartialAsync("LoadedDependencies", false)
+    @await Html.PartialAsync("LoadedDependencies", (bool?)null)
 
-    @await SmidgeHelper.JsHereAsync(debug: false)
+    @await SmidgeHelper.JsHereAsync()
     @await SmidgeHelper.JsHereAsync("test-bundle-1")
     @await SmidgeHelper.JsHereAsync("test-bundle-2")
-    @await SmidgeHelper.JsHereAsync("no-files", debug: false)
+    @await SmidgeHelper.JsHereAsync("no-files")
     @await SmidgeHelper.JsHereAsync("test-bundle-10")
 
     <script src="~/Js/non-bundled.js" asp-append-version="true"></script>

--- a/src/Smidge.Web/Views/Home/SubFolder.cshtml
+++ b/src/Smidge.Web/Views/Home/SubFolder.cshtml
@@ -32,9 +32,9 @@
 <body>
 
     @await Html.PartialAsync("TopBar")
-    @await Html.PartialAsync("LoadedDependencies", false)
+    @await Html.PartialAsync("LoadedDependencies", (bool?)null)
 
-    @await SmidgeHelper.JsHereAsync(debug: false)
+    @await SmidgeHelper.JsHereAsync()
     @await SmidgeHelper.JsHereAsync("test-bundle-1")
     @await SmidgeHelper.JsHereAsync("test-bundle-2")
 

--- a/src/Smidge.Web/Views/Shared/LoadedDependencies.cshtml
+++ b/src/Smidge.Web/Views/Shared/LoadedDependencies.cshtml
@@ -1,5 +1,7 @@
-﻿@model bool
+@model bool?
+
 @using Smidge.Models;
+
 @inject Smidge.SmidgeHelper SmidgeHelper
 @inject Smidge.IBundleManager BundleManager
 

--- a/src/Smidge/Controllers/SmidgeController.cs
+++ b/src/Smidge/Controllers/SmidgeController.cs
@@ -12,6 +12,8 @@ using Microsoft.Extensions.Logging;
 using Smidge.FileProcessors;
 using Smidge.Cache;
 using Microsoft.AspNetCore.Authorization;
+using System.Reflection.Metadata;
+using Smidge.Options;
 
 namespace Smidge.Controllers
 {
@@ -26,6 +28,7 @@ namespace Smidge.Controllers
     [AllowAnonymous]
     public class SmidgeController : Controller
     {
+        private readonly ISmidgeProfileStrategy _profileStrategy;
         private readonly ISmidgeFileSystem _fileSystem;
         private readonly IBundleManager _bundleManager;
         private readonly IBundleFileSetGenerator _fileSetGenerator;
@@ -43,6 +46,7 @@ namespace Smidge.Controllers
         /// <param name="preProcessManager"></param>
         /// <param name="logger"></param>
         public SmidgeController(
+            ISmidgeProfileStrategy profileStrategy,
             ISmidgeFileSystem fileSystemHelper,
             IBundleManager bundleManager,
             IBundleFileSetGenerator fileSetGenerator,
@@ -50,6 +54,7 @@ namespace Smidge.Controllers
             IPreProcessManager preProcessManager,
             ILogger<SmidgeController> logger)
         {
+            _profileStrategy = profileStrategy ?? throw new ArgumentNullException(nameof(profileStrategy));
             _fileSystem = fileSystemHelper ?? throw new ArgumentNullException(nameof(fileSystemHelper));
             _bundleManager = bundleManager ?? throw new ArgumentNullException(nameof(bundleManager));
             _fileSetGenerator = fileSetGenerator ?? throw new ArgumentNullException(nameof(fileSetGenerator));
@@ -71,8 +76,24 @@ namespace Smidge.Controllers
                 return NotFound();
             }
 
-            var bundleOptions = foundBundle.GetBundleOptions(_bundleManager, bundleModel.Debug);
+            string profileName;
 
+            // For backwards compatibility we'll use the Debug profile if it was explicitly requested in the request.
+            if (bundleModel.Debug)
+            {
+                profileName = SmidgeOptionsProfile.Debug;
+            }
+            else
+            {
+                // If the Bundle explicitly specifies a profile to use then use it otherwise use the current profile 
+                profileName = !string.IsNullOrEmpty(foundBundle.ProfileName)
+                    ? foundBundle.ProfileName
+                    : _profileStrategy.GetCurrentProfileName();
+            }
+
+            //get the bundle options from the bundle if they have been set otherwise with the defaults
+            var bundleOptions = foundBundle.GetBundleOptions(_bundleManager, profileName);
+            
             var cacheBusterValue = bundleModel.ParsedPath.CacheBusterValue;
 
             //now we need to determine if this bundle has already been created
@@ -164,7 +185,7 @@ namespace Smidge.Controllers
                 return NotFound();
             }
 
-            var defaultBundleOptions = _bundleManager.GetDefaultBundleOptions(false);
+            //var defaultBundleOptions = _bundleManager.GetDefaultBundleOptions(false);
             var cacheBusterValue = file.ParsedPath.CacheBusterValue;
 
             var cacheFile = _fileSystem.CacheFileSystem.GetCachedCompositeFile(cacheBusterValue, file.Compression, file.FileKey, out var cacheFilePath);

--- a/src/Smidge/SmidgeHelper.cs
+++ b/src/Smidge/SmidgeHelper.cs
@@ -197,8 +197,12 @@ namespace Smidge
             }
             else
             {
-                profileName = _profileStrategy.GetCurrentProfileName();
+                // If the Bundle explicitly specifies a profile to use then use it otherwise use the current profile 
+                profileName = !string.IsNullOrEmpty(bundle.ProfileName)
+                    ? bundle.ProfileName
+                    : _profileStrategy.GetCurrentProfileName();
             }
+            
 
             //get the bundle options from the bundle if they have been set otherwise with the defaults
             var bundleOptions = bundle.GetBundleOptions(_bundleManager, profileName);

--- a/src/Smidge/SmidgeHelper.cs
+++ b/src/Smidge/SmidgeHelper.cs
@@ -217,11 +217,14 @@ namespace Smidge
                     _processorFactory.CreateDefault(
                         //the file type in the bundle will always be the same
                         bundle.Files[0].DependencyType));
-                result.AddRange(files.Select(d => _urlManager.AppendCacheBuster(_requestHelper.Content(d), !bundleOptions.ProcessAsCompositeFile, cacheBusterValue)));
+
+                // For backwards compatibility we'll only generate a debug token in the url if Debug was explicitly requested.
+                result.AddRange(files.Select(d => _urlManager.AppendCacheBuster(_requestHelper.Content(d), debug is true, cacheBusterValue)));
                 return result;
             }
 
-            var url = _urlManager.GetUrl(bundleName, fileExt, !bundleOptions.ProcessAsCompositeFile, cacheBusterValue);
+            // For backwards compatibility we'll only generate a debug token in the url if Debug was explicitly requested.
+            var url = _urlManager.GetUrl(bundleName, fileExt, debug is true, cacheBusterValue);
             if (!string.IsNullOrWhiteSpace(url))
             {
                 result.Add(url);

--- a/src/Smidge/SmidgeStartup.cs
+++ b/src/Smidge/SmidgeStartup.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
@@ -34,6 +34,7 @@ namespace Smidge
             services.TryAddSingleton<IHttpContextAccessor, HttpContextAccessor>();
             services.TryAddSingleton<IActionContextAccessor, ActionContextAccessor>();
 
+            services.AddSingleton<ISmidgeProfileStrategy, DefaultProfileStrategy>();
             services.AddTransient<IConfigureOptions<SmidgeOptions>, SmidgeOptionsSetup>();
 
             services.AddSingleton<IPreProcessManager, PreProcessManager>();

--- a/src/Smidge/TagHelpers/SmidgeLinkTagHelper.cs
+++ b/src/Smidge/TagHelpers/SmidgeLinkTagHelper.cs
@@ -61,8 +61,12 @@ namespace Smidge.TagHelpers
         [HtmlAttributeName(HrefAttributeName)]
         public string Source { get; set; }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether to generate content based on the debug or production configuration profile.
+        /// If left unset then the configured <see cref="ISmidgeProfileStrategy"/> will determine if the debug profile is used.
+        /// </summary>
         [HtmlAttributeName("debug")]
-        public bool Debug { get; set; }
+        public bool? Debug { get; set; }
 
         public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
         {

--- a/src/Smidge/TagHelpers/SmidgeScriptTagHelper.cs
+++ b/src/Smidge/TagHelpers/SmidgeScriptTagHelper.cs
@@ -59,8 +59,12 @@ namespace Smidge.TagHelpers
         [HtmlAttributeName("src")]
         public string Source { get; set; }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether to generate content based on the debug or production configuration profile.
+        /// If left unset then the configured <see cref="ISmidgeProfileStrategy"/> will determine if the debug profile is used.
+        /// </summary>
         [HtmlAttributeName("debug")]
-        public bool Debug { get; set; }
+        public bool? Debug { get; set; }
         
         public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
         {

--- a/test/Smidge.Tests/Helpers/FakeCacheBuster.cs
+++ b/test/Smidge.Tests/Helpers/FakeCacheBuster.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+using Smidge.Cache;
+
+namespace Smidge.Tests.Helpers
+{
+    public class FakeCacheBuster : ICacheBuster
+    {
+
+        public static readonly IEnumerable<ICacheBuster> Instances = new[] { new FakeCacheBuster() };
+
+
+        public string GetValue() => "00000";
+    }
+}

--- a/test/Smidge.Tests/Helpers/FakeProfileStrategy.cs
+++ b/test/Smidge.Tests/Helpers/FakeProfileStrategy.cs
@@ -1,0 +1,29 @@
+using Smidge.Options;
+
+namespace Smidge.Tests.Helpers
+{
+    public class FakeProfileStrategy : ISmidgeProfileStrategy
+    {
+        public static readonly ISmidgeProfileStrategy DebugProfileStrategy = new FakeProfileStrategy(SmidgeOptionsProfile.Debug);
+        public static readonly ISmidgeProfileStrategy DefaultProfileStrategy = new FakeProfileStrategy(SmidgeOptionsProfile.Default);
+
+
+        public FakeProfileStrategy()
+        {
+            ProfileName = SmidgeOptionsProfile.Default;
+        }
+
+        public FakeProfileStrategy(string profileName)
+        {
+            ProfileName = profileName;
+        }
+
+
+        public string ProfileName { get; set; }
+
+
+        public string GetCurrentProfileName() => ProfileName;
+
+        
+    }
+}

--- a/test/Smidge.Tests/Helpers/FakeWebsiteInfo.cs
+++ b/test/Smidge.Tests/Helpers/FakeWebsiteInfo.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace Smidge.Tests.Helpers
+{
+    public class FakeWebsiteInfo : IWebsiteInfo
+    {
+
+        private Uri _baseUrl;
+        public Uri GetBaseUrl() => _baseUrl ??= new Uri("http://test.com");
+
+        public string GetBasePath() => string.Empty;
+    }
+}

--- a/test/Smidge.Tests/SmidgeHelperTests.cs
+++ b/test/Smidge.Tests/SmidgeHelperTests.cs
@@ -1,15 +1,16 @@
 using System;
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Moq;
 using Smidge.CompositeFiles;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Dazinator.Extensions.FileProviders;
+using Dazinator.Extensions.FileProviders.InMemory;
+using Dazinator.Extensions.FileProviders.InMemory.Directory;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Smidge;
 using Smidge.Cache;
 using Smidge.Hashing;
 using Smidge.FileProcessors;
@@ -21,10 +22,9 @@ namespace Smidge.Tests
 {
     public class SmidgeHelperTests
     {
-        private readonly IUrlManager _urlManager = Mock.Of<IUrlManager>();
+        private readonly IUrlManager _urlManager;// = Mock.Of<IUrlManager>();
         private readonly IFileProvider _fileProvider = Mock.Of<IFileProvider>();
         private readonly ICacheFileSystem _cacheProvider = Mock.Of<ICacheFileSystem>();
-        private readonly IFileProviderFilter _fileProviderFilter = Mock.Of<IFileProviderFilter>();
         private readonly IHasher _hasher = Mock.Of<IHasher>();
         private readonly IEnumerable<IPreProcessor> _preProcessors = new List<IPreProcessor>();
         private readonly IBundleFileSetGenerator _fileSetGenerator;
@@ -35,35 +35,44 @@ namespace Smidge.Tests
         private readonly PreProcessPipelineFactory _processorFactory;
         private readonly IBundleManager _bundleManager;
         private readonly IRequestHelper _requestHelper;
+        private readonly CacheBusterResolver _cacheBusterResolver;
         private readonly Mock<IHttpContextAccessor> _httpContextAccessor;
-        private Mock<HttpContext> _httpContext;
 
 
         public SmidgeHelperTests()
         {
-            //  var config = Mock.Of<ISmidgeConfig>();
-            _httpContext = new Mock<HttpContext>();
             _httpContextAccessor = new Mock<IHttpContextAccessor>();
-            _httpContextAccessor.Setup(x => x.HttpContext).Returns(_httpContext.Object);
+            _httpContextAccessor.Setup(x => x.HttpContext).Returns(Mock.Of<HttpContext>);
 
             _dynamicallyRegisteredWebFiles = new DynamicallyRegisteredWebFiles();
-            _fileSystemHelper = new SmidgeFileSystem(_fileProvider, _fileProviderFilter, _cacheProvider, Mock.Of<IWebsiteInfo>());
+            _fileSystemHelper = new SmidgeFileSystem(_fileProvider, new DefaultFileProviderFilter(), _cacheProvider, new FakeWebsiteInfo());
 
             _smidgeOptions = new Mock<IOptions<SmidgeOptions>>();
-            _smidgeOptions.Setup(opt => opt.Value).Returns(new SmidgeOptions
+            _smidgeOptions.Setup(opt => opt.Value).Returns(() =>
             {
-                DefaultBundleOptions = new BundleEnvironmentOptions()
+                var options = new SmidgeOptions
+                {
+                    UrlOptions = new UrlManagerOptions(),
+                    DefaultBundleOptions = new BundleEnvironmentOptions()
+                };
+                options.DefaultBundleOptions.DebugOptions.SetCacheBusterType<FakeCacheBuster>();
+                options.DefaultBundleOptions.ProductionOptions.SetCacheBusterType<FakeCacheBuster>();
+                return options;
             });
 
-            _requestHelper = Mock.Of<IRequestHelper>();
+            _requestHelper = new RequestHelper(new FakeWebsiteInfo());
+            _urlManager = new DefaultUrlManager(_smidgeOptions.Object, _hasher, _requestHelper);
+
+            _cacheBusterResolver = new CacheBusterResolver(FakeCacheBuster.Instances);
+            
             _processorFactory = new PreProcessPipelineFactory(new Lazy<IEnumerable<IPreProcessor>>(() => _preProcessors));
             _bundleManager = new BundleManager(_smidgeOptions.Object, Mock.Of<ILogger<BundleManager>>());
             _preProcessManager = new PreProcessManager(
-                _fileSystemHelper,                
-                _bundleManager, 
+                _fileSystemHelper,
+                _bundleManager,
                 Mock.Of<ILogger<PreProcessManager>>());
             _fileSetGenerator = new BundleFileSetGenerator(
-                _fileSystemHelper, 
+                _fileSystemHelper,
                 new FileProcessingConventions(_smidgeOptions.Object, new List<IFileProcessingConvention>()));
         }
 
@@ -73,10 +82,9 @@ namespace Smidge.Tests
             var sut = new SmidgeHelper(
                 FakeProfileStrategy.DefaultProfileStrategy,
                 _fileSetGenerator,
-                _dynamicallyRegisteredWebFiles, _preProcessManager, _fileSystemHelper, 
+                _dynamicallyRegisteredWebFiles, _preProcessManager, _fileSystemHelper,
                 _hasher, _bundleManager, _processorFactory, _urlManager, _requestHelper,
-                _httpContextAccessor.Object,
-                new CacheBusterResolver(Enumerable.Empty<ICacheBuster>()));
+                _httpContextAccessor.Object, _cacheBusterResolver);
 
             _bundleManager.CreateJs("empty", Array.Empty<string>());
 
@@ -90,10 +98,9 @@ namespace Smidge.Tests
             var sut = new SmidgeHelper(
                 FakeProfileStrategy.DebugProfileStrategy,
                 _fileSetGenerator,
-                _dynamicallyRegisteredWebFiles, _preProcessManager, _fileSystemHelper, 
-                _hasher, _bundleManager, _processorFactory, _urlManager, _requestHelper,                
-                _httpContextAccessor.Object, 
-                new CacheBusterResolver(Enumerable.Empty<ICacheBuster>()));
+                _dynamicallyRegisteredWebFiles, _preProcessManager, _fileSystemHelper,
+                _hasher, _bundleManager, _processorFactory, _urlManager, _requestHelper,
+                _httpContextAccessor.Object, _cacheBusterResolver);
 
             var exception = await Assert.ThrowsAsync<BundleNotFoundException>
                     (
@@ -104,6 +111,101 @@ namespace Smidge.Tests
         }
 
 
+
+        [Fact]
+        public async Task Generate_Css_Urls_Returns_SingleBundleUrl_When_Default_Profile_Is_Used()
+        {
+            var sut = new SmidgeHelper(
+                FakeProfileStrategy.DefaultProfileStrategy,
+                _fileSetGenerator,
+                _dynamicallyRegisteredWebFiles, _preProcessManager, _fileSystemHelper,
+                _hasher, _bundleManager, _processorFactory, _urlManager, _requestHelper,
+                _httpContextAccessor.Object, _cacheBusterResolver);
+
+            _bundleManager.CreateCss("test", new[]
+            {
+                "file1.css",
+                "file2.css"
+            });
+
+            var dir = new InMemoryDirectory();
+            dir.AddFile("", new StringFileInfo("File1", "file1.css"));
+            dir.AddFile("", new StringFileInfo("File2", "file2.css"));
+            var fileProvider = new InMemoryFileProvider(dir);
+
+            // Configure the mock file provider to use the temporary file provider we've just configured
+            Mock.Get(_fileProvider).Setup(f => f.GetFileInfo(It.IsAny<string>())).Returns((string s) => fileProvider.GetFileInfo(s));
+            Mock.Get(_fileProvider).Setup(f => f.GetDirectoryContents(It.IsAny<string>())).Returns((string s) => fileProvider.GetDirectoryContents(s));
+
+            var urls = await sut.GenerateCssUrlsAsync("test");
+
+            Assert.Equal("/sb/test.css.v00000", urls.FirstOrDefault());
+        }
+
+
+        [Fact]
+        public async Task Generate_Css_Urls_Returns_Multiple_Urls_When_Debug_Profile_Is_Used()
+        {
+            var sut = new SmidgeHelper(
+                FakeProfileStrategy.DebugProfileStrategy,
+                _fileSetGenerator,
+                _dynamicallyRegisteredWebFiles, _preProcessManager, _fileSystemHelper,
+                _hasher, _bundleManager, _processorFactory, _urlManager, _requestHelper,
+                _httpContextAccessor.Object, _cacheBusterResolver);
+
+            _bundleManager.CreateCss("test", new[]
+            {
+                "file1.css",
+                "file2.css"
+            });
+
+            var dir = new InMemoryDirectory();
+            dir.AddFile("", new StringFileInfo("File1", "file1.css"));
+            dir.AddFile("", new StringFileInfo("File2", "file2.css"));
+            var fileProvider = new InMemoryFileProvider(dir);
+
+            // Configure the mock file provider to use the temporary file provider we've just configured
+            Mock.Get(_fileProvider).Setup(f => f.GetFileInfo(It.IsAny<string>())).Returns((string s) => fileProvider.GetFileInfo(s));
+            Mock.Get(_fileProvider).Setup(f => f.GetDirectoryContents(It.IsAny<string>())).Returns((string s) => fileProvider.GetDirectoryContents(s));
+
+            var urls = await sut.GenerateJsUrlsAsync("test");
+
+            Assert.Equal("/file1.css?d=00000", urls.ElementAtOrDefault(0));
+            Assert.Equal("/file2.css?d=00000", urls.ElementAtOrDefault(1));
+        }
+
+        [Fact]
+        public async Task Generate_Css_Urls_Returns_Multiple_Urls_When_Debug_Parameter_Overrides_Profile()
+        {
+            var sut = new SmidgeHelper(
+                FakeProfileStrategy.DefaultProfileStrategy,
+                _fileSetGenerator,
+                _dynamicallyRegisteredWebFiles, _preProcessManager, _fileSystemHelper,
+                _hasher, _bundleManager, _processorFactory, _urlManager, _requestHelper,
+                _httpContextAccessor.Object, _cacheBusterResolver);
+
+            _bundleManager.CreateCss("test", new[]
+            {
+                "file1.css",
+                "file2.css"
+            });
+
+            var dir = new InMemoryDirectory();
+            dir.AddFile("", new StringFileInfo("File1", "file1.css"));
+            dir.AddFile("", new StringFileInfo("File2", "file2.css"));
+            var fileProvider = new InMemoryFileProvider(dir);
+
+            // Configure the mock file provider to use the temporary file provider we've just configured
+            Mock.Get(_fileProvider).Setup(f => f.GetFileInfo(It.IsAny<string>())).Returns((string s) => fileProvider.GetFileInfo(s));
+            Mock.Get(_fileProvider).Setup(f => f.GetDirectoryContents(It.IsAny<string>())).Returns((string s) => fileProvider.GetDirectoryContents(s));
+
+            var urls = await sut.GenerateJsUrlsAsync("test", debug: true);
+
+            Assert.Equal("/file1.css?d=00000", urls.ElementAtOrDefault(0));
+            Assert.Equal("/file2.css?d=00000", urls.ElementAtOrDefault(1));
+        }
+
+
         [Fact]
         public async Task Generate_Js_Urls_For_Non_Existent_Bundle_Throws_Exception()
         {
@@ -111,18 +213,113 @@ namespace Smidge.Tests
             var sut = new SmidgeHelper(
                 FakeProfileStrategy.DebugProfileStrategy,
                 _fileSetGenerator,
-                _dynamicallyRegisteredWebFiles, _preProcessManager, _fileSystemHelper, 
+                _dynamicallyRegisteredWebFiles, _preProcessManager, _fileSystemHelper,
                 _hasher, _bundleManager, _processorFactory, _urlManager, _requestHelper,
-                _httpContextAccessor.Object,
-                new CacheBusterResolver(Enumerable.Empty<ICacheBuster>()));
+                _httpContextAccessor.Object, _cacheBusterResolver);
 
             var exception = await Assert.ThrowsAsync<BundleNotFoundException>
                     (
                         async () => await sut.GenerateJsUrlsAsync("DoesntExist")
                     );
-
-
         }
+
+
+
+
+        [Fact]
+        public async Task Generate_Js_Urls_Returns_SingleBundleUrl_When_Default_Profile_Is_Used()
+        {
+            var sut = new SmidgeHelper(
+                FakeProfileStrategy.DefaultProfileStrategy,
+                _fileSetGenerator,
+                _dynamicallyRegisteredWebFiles, _preProcessManager, _fileSystemHelper,
+                _hasher, _bundleManager, _processorFactory, _urlManager, _requestHelper,
+                _httpContextAccessor.Object, _cacheBusterResolver);
+
+            _bundleManager.CreateJs("test", new[]
+            {
+                "file1.js",
+                "file2.js"
+            });
+
+            var dir = new InMemoryDirectory();
+            dir.AddFile("", new StringFileInfo("File1", "file1.js"));
+            dir.AddFile("", new StringFileInfo("File2", "file2.js"));
+            var fileProvider = new InMemoryFileProvider(dir);
+
+            // Configure the mock file provider to use the temporary file provider we've just configured
+            Mock.Get(_fileProvider).Setup(f => f.GetFileInfo(It.IsAny<string>())).Returns((string s) => fileProvider.GetFileInfo(s));
+            Mock.Get(_fileProvider).Setup(f => f.GetDirectoryContents(It.IsAny<string>())).Returns((string s) => fileProvider.GetDirectoryContents(s));
+
+            var urls = await sut.GenerateJsUrlsAsync("test");
+
+            Assert.Equal("/sb/test.js.v00000", urls.FirstOrDefault());
+        }
+
+
+        [Fact]
+        public async Task Generate_Js_Urls_Returns_Multiple_Urls_When_Debug_Profile_Is_Used()
+        {
+            var sut = new SmidgeHelper(
+                FakeProfileStrategy.DebugProfileStrategy,
+                _fileSetGenerator,
+                _dynamicallyRegisteredWebFiles, _preProcessManager, _fileSystemHelper,
+                _hasher, _bundleManager, _processorFactory, _urlManager, _requestHelper,
+                _httpContextAccessor.Object, _cacheBusterResolver);
+
+            _bundleManager.CreateJs("test", new[]
+            {
+                "file1.js",
+                "file2.js"
+            });
+
+            var dir = new InMemoryDirectory();
+            dir.AddFile("", new StringFileInfo("File1", "file1.js"));
+            dir.AddFile("", new StringFileInfo("File2", "file2.js"));
+            var fileProvider = new InMemoryFileProvider(dir);
+
+            // Configure the mock file provider to use the temporary file provider we've just configured
+            Mock.Get(_fileProvider).Setup(f => f.GetFileInfo(It.IsAny<string>())).Returns((string s) => fileProvider.GetFileInfo(s));
+            Mock.Get(_fileProvider).Setup(f => f.GetDirectoryContents(It.IsAny<string>())).Returns((string s) => fileProvider.GetDirectoryContents(s));
+
+            var urls = await sut.GenerateJsUrlsAsync("test");
+
+            Assert.Equal("/file1.js?d=00000", urls.ElementAtOrDefault(0));
+            Assert.Equal("/file2.js?d=00000", urls.ElementAtOrDefault(1));
+        }
+
+        [Fact]
+        public async Task Generate_Js_Urls_Returns_Multiple_Urls_When_Debug_Parameter_Overrides_Profile()
+        {
+            var sut = new SmidgeHelper(
+                FakeProfileStrategy.DefaultProfileStrategy,
+                _fileSetGenerator,
+                _dynamicallyRegisteredWebFiles, _preProcessManager, _fileSystemHelper,
+                _hasher, _bundleManager, _processorFactory, _urlManager, _requestHelper,
+                _httpContextAccessor.Object, _cacheBusterResolver);
+
+            _bundleManager.CreateJs("test", new[]
+            {
+                "file1.js",
+                "file2.js"
+            });
+
+            var dir = new InMemoryDirectory();
+            dir.AddFile("", new StringFileInfo("File1", "file1.js"));
+            dir.AddFile("", new StringFileInfo("File2", "file2.js"));
+            var fileProvider = new InMemoryFileProvider(dir);
+
+            // Configure the mock file provider to use the temporary file provider we've just configured
+            Mock.Get(_fileProvider).Setup(f => f.GetFileInfo(It.IsAny<string>())).Returns((string s) => fileProvider.GetFileInfo(s));
+            Mock.Get(_fileProvider).Setup(f => f.GetDirectoryContents(It.IsAny<string>())).Returns((string s) => fileProvider.GetDirectoryContents(s));
+
+            var urls = await sut.GenerateJsUrlsAsync("test", debug: true);
+
+            Assert.Equal("/file1.js?d=00000", urls.ElementAtOrDefault(0));
+            Assert.Equal("/file2.js?d=00000", urls.ElementAtOrDefault(1));
+        }
+
+
 
         [Fact]
         public async Task CssHere_HtmlString_For_Non_Existent_Css_Bundle_Throws_Exception()
@@ -131,10 +328,9 @@ namespace Smidge.Tests
             var sut = new SmidgeHelper(
                 FakeProfileStrategy.DebugProfileStrategy,
                 _fileSetGenerator,
-                _dynamicallyRegisteredWebFiles, _preProcessManager, _fileSystemHelper, 
+                _dynamicallyRegisteredWebFiles, _preProcessManager, _fileSystemHelper,
                 _hasher, _bundleManager, _processorFactory, _urlManager, _requestHelper,
-                _httpContextAccessor.Object,
-                new CacheBusterResolver(Enumerable.Empty<ICacheBuster>()));
+                _httpContextAccessor.Object, _cacheBusterResolver);
 
             var exception = await Assert.ThrowsAsync<BundleNotFoundException>
                     (
@@ -156,10 +352,9 @@ namespace Smidge.Tests
             var sut = new SmidgeHelper(
                 FakeProfileStrategy.DebugProfileStrategy,
                 _fileSetGenerator,
-                _dynamicallyRegisteredWebFiles, _preProcessManager, _fileSystemHelper, 
+                _dynamicallyRegisteredWebFiles, _preProcessManager, _fileSystemHelper,
                 _hasher, _bundleManager, _processorFactory, _urlManager, _requestHelper,
-                _httpContextAccessor.Object,
-                new CacheBusterResolver(Enumerable.Empty<ICacheBuster>()));
+                _httpContextAccessor.Object, _cacheBusterResolver);
 
             var exception = await Assert.ThrowsAsync<BundleNotFoundException>
                     (

--- a/test/Smidge.Tests/SmidgeHelperTests.cs
+++ b/test/Smidge.Tests/SmidgeHelperTests.cs
@@ -14,6 +14,7 @@ using Smidge.Cache;
 using Smidge.Hashing;
 using Smidge.FileProcessors;
 using Smidge.Options;
+using Smidge.Tests.Helpers;
 using Xunit;
 
 namespace Smidge.Tests
@@ -47,6 +48,7 @@ namespace Smidge.Tests
 
             _dynamicallyRegisteredWebFiles = new DynamicallyRegisteredWebFiles();
             _fileSystemHelper = new SmidgeFileSystem(_fileProvider, _fileProviderFilter, _cacheProvider, Mock.Of<IWebsiteInfo>());
+
             _smidgeOptions = new Mock<IOptions<SmidgeOptions>>();
             _smidgeOptions.Setup(opt => opt.Value).Returns(new SmidgeOptions
             {
@@ -69,6 +71,7 @@ namespace Smidge.Tests
         public async Task JsHereAsync_Returns_Empty_String_Result_When_No_Files_Found()
         {
             var sut = new SmidgeHelper(
+                FakeProfileStrategy.DefaultProfileStrategy,
                 _fileSetGenerator,
                 _dynamicallyRegisteredWebFiles, _preProcessManager, _fileSystemHelper, 
                 _hasher, _bundleManager, _processorFactory, _urlManager, _requestHelper,
@@ -77,7 +80,7 @@ namespace Smidge.Tests
 
             _bundleManager.CreateJs("empty", Array.Empty<string>());
 
-            var result = (await sut.JsHereAsync("empty", false)).ToString();
+            var result = (await sut.JsHereAsync("empty")).ToString();
             Assert.Equal(string.Empty, result);
         }
 
@@ -85,6 +88,7 @@ namespace Smidge.Tests
         public async Task Generate_Css_Urls_For_Non_Existent_Bundle_Throws_Exception()
         {
             var sut = new SmidgeHelper(
+                FakeProfileStrategy.DebugProfileStrategy,
                 _fileSetGenerator,
                 _dynamicallyRegisteredWebFiles, _preProcessManager, _fileSystemHelper, 
                 _hasher, _bundleManager, _processorFactory, _urlManager, _requestHelper,                
@@ -93,7 +97,7 @@ namespace Smidge.Tests
 
             var exception = await Assert.ThrowsAsync<BundleNotFoundException>
                     (
-                        async () => await sut.GenerateCssUrlsAsync("DoesntExist", true)
+                        async () => await sut.GenerateCssUrlsAsync("DoesntExist")
 
                     );
 
@@ -105,6 +109,7 @@ namespace Smidge.Tests
         {
 
             var sut = new SmidgeHelper(
+                FakeProfileStrategy.DebugProfileStrategy,
                 _fileSetGenerator,
                 _dynamicallyRegisteredWebFiles, _preProcessManager, _fileSystemHelper, 
                 _hasher, _bundleManager, _processorFactory, _urlManager, _requestHelper,
@@ -113,7 +118,7 @@ namespace Smidge.Tests
 
             var exception = await Assert.ThrowsAsync<BundleNotFoundException>
                     (
-                        async () => await sut.GenerateJsUrlsAsync("DoesntExist", true)
+                        async () => await sut.GenerateJsUrlsAsync("DoesntExist")
                     );
 
 
@@ -124,6 +129,7 @@ namespace Smidge.Tests
         {
 
             var sut = new SmidgeHelper(
+                FakeProfileStrategy.DebugProfileStrategy,
                 _fileSetGenerator,
                 _dynamicallyRegisteredWebFiles, _preProcessManager, _fileSystemHelper, 
                 _hasher, _bundleManager, _processorFactory, _urlManager, _requestHelper,
@@ -148,6 +154,7 @@ namespace Smidge.Tests
         {
 
             var sut = new SmidgeHelper(
+                FakeProfileStrategy.DebugProfileStrategy,
                 _fileSetGenerator,
                 _dynamicallyRegisteredWebFiles, _preProcessManager, _fileSystemHelper, 
                 _hasher, _bundleManager, _processorFactory, _urlManager, _requestHelper,

--- a/test/Smidge.Tests/SmidgeHelperTests.cs
+++ b/test/Smidge.Tests/SmidgeHelperTests.cs
@@ -170,12 +170,13 @@ namespace Smidge.Tests
 
             var urls = await sut.GenerateJsUrlsAsync("test");
 
-            Assert.Equal("/file1.css?d=00000", urls.ElementAtOrDefault(0));
-            Assert.Equal("/file2.css?d=00000", urls.ElementAtOrDefault(1));
+            Assert.Equal("/file1.css?v=00000", urls.ElementAtOrDefault(0));
+            Assert.Equal("/file2.css?v=00000", urls.ElementAtOrDefault(1));
         }
 
+
         [Fact]
-        public async Task Generate_Css_Urls_Returns_Multiple_Urls_When_Debug_Parameter_Overrides_Profile()
+        public async Task Generate_Css_Urls_Returns_Urls_With_Debug_Token_When_Debug_Parameter_Overrides_Profile()
         {
             var sut = new SmidgeHelper(
                 FakeProfileStrategy.DefaultProfileStrategy,
@@ -284,12 +285,13 @@ namespace Smidge.Tests
 
             var urls = await sut.GenerateJsUrlsAsync("test");
 
-            Assert.Equal("/file1.js?d=00000", urls.ElementAtOrDefault(0));
-            Assert.Equal("/file2.js?d=00000", urls.ElementAtOrDefault(1));
+            Assert.Equal("/file1.js?v=00000", urls.ElementAtOrDefault(0));
+            Assert.Equal("/file2.js?v=00000", urls.ElementAtOrDefault(1));
         }
 
+
         [Fact]
-        public async Task Generate_Js_Urls_Returns_Multiple_Urls_When_Debug_Parameter_Overrides_Profile()
+        public async Task Generate_Js_Urls_Returns_Urls_With_Debug_Token_When_Debug_Parameter_Overrides_Profile()
         {
             var sut = new SmidgeHelper(
                 FakeProfileStrategy.DefaultProfileStrategy,


### PR DESCRIPTION
This PR aims to add make it easier to configure different sets of options for different request scenarios. 

I started out coming at this from the perspective that I don't like the current method of enabling "debugging" output (ie: unbundled file output). I really wanted to make it easier to have debugging output automatically enabled when developing locally, but disabled for production use. Prior to this PR, you have to explicitly pass a debug parameter to the various SmidgeHelper methods (and TagHelpers). This made it cumbersome to globally enable/disable debugging output and put a lot of onus on the user to determine when debugging should be enabled or not. 

For example, the documentation suggests the following to achieve debugging output during development. 

```
<environment names="Development">
    <script src="my-awesome-js-bundle" type="text/javascript" debug="true"></script>
</environment>
<environment names="Staging,Production">
    <script src="my-awesome-js-bundle" type="text/javascript"></script>
</environment>
```

But if you have multiple bundles in various places (think CSS in the page head, JS in the footer) etc then this becomes pretty verbose.

### My Solution
I have added the concept of Named Profiles - where a profile is represented by the existing BundleOptions class. The existing BundleEnvironmentOptions is now responsible for managing the various profile configurations. The existing Debug and Production BundleOptions remain, but it is possible to add additional "named" options.
Secondly, I've added the ISmidgeProfileStrategy interface and a couple of default implementations. This interface is used by the SmidgeHelper to decide which profile (ie: pre-configured BundleOptions) to use for a given request. 

The DefaultProfileStrategy is configured in the DI container. It just uses the Default (synonym for existing Production options) profile for all requests. I think this maintains the current out-of-the-box functionality.
There is also a HostEnvironmentProfileStrategy which if configured in the DI container will use the current IHostEnvironment to determine if the Debug or Default profile should be used. 

Now its as simple as 
`services.AddSingleton<ISmidgeProfileStrategy, HostEnvironmentProfileStrategy>();`
and you get debug output when developing locally and standard output for anything other than the Development environment.

As I said above, I was primarily wanting to make debug output easier to enable. But I think these changes offer even more extensibility. It is now possible to configure multiple sets of BundleOptions for different scenarios, and then either refer to the named profile when defining a Bundle or use a custom implementation of ISmidgeProfileStrategy that determines which BundleOptions to use at run time. 

For example
 ```
  services.Configure<SmidgeOptions>(options =>
            {
                // Create some custom profiles with specific configurations
                var noCompressionProfile = options.DefaultBundleOptions["NoCompression"];
                noCompressionProfile.ProcessAsCompositeFile = true;
                noCompressionProfile.CompressResult = false;

                var cacheForeverProfile = options.DefaultBundleOptions["CacheForever"];
                cacheForeverProfile.ProcessAsCompositeFile = true;
                cacheForeverProfile.CacheControlOptions.CacheControlMaxAge = 99999;
            });
```
```
app.UseSmidge(bundles =>
            {
                bundles.CreateJs("bundle-1", "~/Js/1.js", "~/Js/2.js")
                    .UseProfile("NoCompression");
            });
```

or 

```
    public class MyCustomProfileStrategy : ISmidgeProfileStrategy
    {
        private readonly HttpContext _httpContext;
        
        public MyCustomProfileStrategy(HttpContext httpContext) => _httpContext = httpContext;

        public string GetCurrentProfileName()
        {
            // Pick a Profile based on the request
            return _httpContext.Request.Host.Value.Contains("something")
                ? "NoCompression"
                : "CacheForever";
        }
    }
```

### Backwards Compatibility
I've tried to maintain backwards compatibility, so I think this will be a fairly simple upgrade for most existing users. The debug parameter on the SmidgeHelper and the TagHelpers has been maintained although it has been changed to a Nullable<boolean>. If the property is explicitly set it will override the profile configured during setup. 
At some point in the future I think it would be good to remove the debug parameter as it will simplify the SmidgeHelper API surface area. 