### PR TITLE
chore(targetframework): Added .Net 6.0 as targetframework

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -23,6 +23,6 @@
     <VersionPrefix>4.0.0</VersionPrefix>
   </PropertyGroup>
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
fixes #167

Added .Net 6.0 and ordered the frameworks newest to oldest. As requested here: https://twitter.com/DevNikcio/status/1586017738501328897

I've run the tests locally and it seems to have no effect of them so it should be good to go.