### PR TITLE
fix: Update obsolete methods

### DIFF
--- a/src/Smidge.Nuglify/SourceMapDeclaration.cs
+++ b/src/Smidge.Nuglify/SourceMapDeclaration.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using Microsoft.Extensions.Options;
 using Smidge.Cache;
@@ -66,7 +66,7 @@ namespace Smidge.Nuglify
                 string.Format(
                     handler,
                     _smidgeOptions.Value.UrlOptions.BundleFilePath + "/nmap",
-                    Uri.EscapeUriString(bundleName),
+                    Uri.EscapeDataString(bundleName),
                     fileExtension,
                     debug ? 'd' : 'v',
                     cacheBusterValue));

--- a/test/Smidge.Benchmarks/JsMinifyBenchmarks.cs
+++ b/test/Smidge.Benchmarks/JsMinifyBenchmarks.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -53,8 +53,8 @@ namespace Smidge.Benchmarks
         {
             public Config()
             {
-                Add(MemoryDiagnoser.Default);
-                Add(new MinifiedPercentColumn());
+                AddDiagnoser(MemoryDiagnoser.Default);
+                AddColumn(new MinifiedPercentColumn());
 
                 ////The 'quick and dirty' settings, so it runs a little quicker
                 //// see benchmarkdotnet FAQ


### PR DESCRIPTION
Updated methods marked obsolete with direct replacements:

- `Uri.EscapeUriString(String)` (https://aka.ms/dotnet-warnings/SYSLIB0013)
- `'ManualConfig.Add(params IColumn[])' is obsolete: 'This method will soon be removed, please start using .AddColumn() instead.'`
- `'ManualConfig.Add(params IDiagnoser[])' is obsolete: 'This method will soon be removed, please start using .AddDiagnoser() instead.'`