### PR TITLE
test: Add .Net 6 multitargeting to test project

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,11 @@ jobs:
       with:
         dotnet-version: 5.0.x
 
+    - name: Setup .NET Core SDK 6.0.x
+      uses: actions/setup-dotnet@v1.7.2
+      with:
+        dotnet-version: 6.0.x
+
     - name: Install GitVersion
       uses: gittools/actions/gitversion/setup@v0.9.9
       with:

--- a/test/Smidge.Tests/Smidge.Tests.csproj
+++ b/test/Smidge.Tests/Smidge.Tests.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net5.0</TargetFrameworks>
     <AssemblyName>Smidge.Tests</AssemblyName>
     <PackageId>Smidge.Tests</PackageId>
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
Related to #168 

Adds .Net 6 to the test project and adds support for .Net 6 in the build workflow in GitHub actions