### PR TITLE
Replaced FileNotFoundException with log instead (#199)

### DIFF
--- a/Nuget.config
+++ b/Nuget.config
@@ -1,8 +1,7 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <add key="AspNetCiDev" value="https://www.myget.org/F/aspnetcidev/api/v3/index.json" />
     <add key="XUnitDev" value="https://www.myget.org/F/xunit/api/v3/index.json" />
   </packageSources>  
 </configuration>

--- a/src/Smidge.Core/SmidgeFileSystem.cs
+++ b/src/Smidge.Core/SmidgeFileSystem.cs
@@ -8,6 +8,7 @@ using Smidge.Models;
 using Smidge.Options;
 using Smidge.Cache;
 using System.Linq;
+using Microsoft.Extensions.Logging;
 
 namespace Smidge
 {
@@ -21,17 +22,20 @@ namespace Smidge
         private readonly IWebsiteInfo _siteInfo;
         private readonly IFileProvider _sourceFileProvider;
         private readonly IFileProviderFilter _fileProviderFilter;
+        private readonly ILogger _logger;
 
         public SmidgeFileSystem(
             IFileProvider sourceFileProvider,
             IFileProviderFilter fileProviderFilter,
             ICacheFileSystem cacheFileProvider,
-            IWebsiteInfo siteInfo)
+            IWebsiteInfo siteInfo,
+            ILogger logger)
         {
             _sourceFileProvider = sourceFileProvider;
             _fileProviderFilter = fileProviderFilter;
             CacheFileSystem = cacheFileProvider;
             _siteInfo = siteInfo;
+            _logger = logger;
         }
 
         public ICacheFileSystem CacheFileSystem { get; }
@@ -43,7 +47,7 @@ namespace Smidge
 
             if (!fileInfo.Exists)
             {
-                throw new FileNotFoundException($"No such file exists {fileInfo.PhysicalPath ?? fileInfo.Name} (mapped from {path})", fileInfo.PhysicalPath ?? fileInfo.Name);
+                _logger.LogError("No such file exists {FileName} (mapped from {FilePath})", fileInfo.PhysicalPath ?? fileInfo.Name, path);
             }
 
             return fileInfo;
@@ -56,7 +60,7 @@ namespace Smidge
 
             if (!fileInfo.Exists)
             {
-                throw new FileNotFoundException($"No such file exists {fileInfo.PhysicalPath ?? fileInfo.Name} (mapped from {filePath})", fileInfo.PhysicalPath ?? fileInfo.Name);
+                _logger.LogError("No such file exists {FileName} (mapped from {FilePath})", fileInfo.PhysicalPath ?? fileInfo.Name, filePath);
             }
 
             return fileInfo;

--- a/src/Smidge.InMemory/ConfiguredCacheFileSystem.cs
+++ b/src/Smidge.InMemory/ConfiguredCacheFileSystem.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Hosting;
@@ -10,6 +10,7 @@ using Smidge.Options;
 using System;
 using System.IO;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 
 namespace Smidge.InMemory
 {
@@ -31,14 +32,19 @@ namespace Smidge.InMemory
 
             if (_options.CacheOptions.UseInMemoryCache)
             {
-                _wrapped = new MemoryCacheFileSystem(hasher);
+                var logger = services.GetRequiredService<ILogger<MemoryCacheFileSystem>>();
+
+                _wrapped = new MemoryCacheFileSystem(hasher, logger);
             }
             else
             {
+                var logger = services.GetRequiredService<ILogger<PhysicalFileCacheFileSystem>>();
+
                 _wrapped = PhysicalFileCacheFileSystem.CreatePhysicalFileCacheFileSystem(
                     hasher,
                     services.GetRequiredService<ISmidgeConfig>(),
-                    services.GetRequiredService<IHostEnvironment>());
+                    services.GetRequiredService<IHostEnvironment>(),
+                    logger);
             }
         }
 

--- a/src/Smidge.InMemory/MemoryCacheFileSystem.cs
+++ b/src/Smidge.InMemory/MemoryCacheFileSystem.cs
@@ -1,7 +1,8 @@
-﻿using Dazinator.Extensions.FileProviders;
+using Dazinator.Extensions.FileProviders;
 using Dazinator.Extensions.FileProviders.InMemory;
 using Dazinator.Extensions.FileProviders.InMemory.Directory;
 using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Logging;
 using Smidge.Cache;
 using Smidge.Hashing;
 using Smidge.Models;
@@ -17,12 +18,14 @@ namespace Smidge.InMemory
         private readonly IDirectory _directory;
         private readonly IHasher _hasher;
         private readonly IFileProvider _fileProvider;
+        private readonly ILogger _logger;
 
-        public MemoryCacheFileSystem(IHasher hasher)
+        public MemoryCacheFileSystem(IHasher hasher, ILogger logger)
         {
             _directory = new InMemoryDirectory();
             _fileProvider = new InMemoryFileProvider(_directory);
             _hasher = hasher;
+            _logger = logger;
         }
 
         public IFileInfo GetRequiredFileInfo(string filePath)
@@ -31,7 +34,7 @@ namespace Smidge.InMemory
 
             if (!fileInfo.Exists)
             {
-                throw new FileNotFoundException($"No such file exists {fileInfo.PhysicalPath ?? fileInfo.Name} (mapped from {filePath})", fileInfo.PhysicalPath ?? fileInfo.Name);
+                _logger.LogError("No such file exists {FileName} (mapped from {FilePath})", fileInfo.PhysicalPath ?? fileInfo.Name, filePath);
             }
 
             return fileInfo;

--- a/src/Smidge/SmidgeStartup.cs
+++ b/src/Smidge/SmidgeStartup.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
@@ -17,6 +17,7 @@ using Smidge.Options;
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+using Microsoft.Extensions.Logging;
 
 [assembly: InternalsVisibleTo("Smidge.Tests")]
 
@@ -47,6 +48,7 @@ namespace Smidge
             services.AddSingleton<ISmidgeFileSystem>(p =>
             {
                 var hosting = p.GetRequiredService<IWebHostEnvironment>();
+                var logger = p.GetRequiredService<ILogger<SmidgeFileSystem>>();
 
                 //resolve the ISmidgeFileProvider if there is one
                 var provider = p.GetService<ISmidgeFileProvider>() ?? hosting.WebRootFileProvider;
@@ -54,13 +56,15 @@ namespace Smidge
                     provider,
                     p.GetRequiredService<IFileProviderFilter>(),
                     p.GetRequiredService<ICacheFileSystem>(),
-                    p.GetRequiredService<IWebsiteInfo>());
+                    p.GetRequiredService<IWebsiteInfo>(),
+                    logger);
             });
             
             services.AddSingleton<ICacheFileSystem>(p => PhysicalFileCacheFileSystem.CreatePhysicalFileCacheFileSystem(
                 p.GetRequiredService<IHasher>(),
                 p.GetRequiredService<ISmidgeConfig>(),
-                p.GetRequiredService<IHostEnvironment>()));
+                p.GetRequiredService<IHostEnvironment>(),
+                p.GetRequiredService<ILogger<PhysicalFileCacheFileSystem>>()));
 
             services.AddSingleton<ISmidgeConfig>((p) =>
             {

--- a/test/Smidge.Tests/BundleFileSetGeneratorTests.cs
+++ b/test/Smidge.Tests/BundleFileSetGeneratorTests.cs
@@ -9,6 +9,7 @@ using Smidge.Models;
 using Smidge.Hashing;
 using Smidge.Options;
 using System.Linq;
+using Microsoft.Extensions.Logging;
 using Smidge.FileProcessors;
 using Microsoft.Extensions.Options;
 using Smidge.Cache;
@@ -28,9 +29,10 @@ namespace Smidge.Tests
 
             var fileProvider = new Mock<IFileProvider>();
             var cacheProvider = new Mock<ICacheFileSystem>();
+            var logger = new Mock<ILogger>();
             var fileProviderFilter = new DefaultFileProviderFilter();
 
-            var fileSystemHelper = new SmidgeFileSystem(fileProvider.Object, fileProviderFilter, cacheProvider.Object, Mock.Of<IWebsiteInfo>());
+            var fileSystemHelper = new SmidgeFileSystem(fileProvider.Object, fileProviderFilter, cacheProvider.Object, Mock.Of<IWebsiteInfo>(), logger.Object);
             var pipeline = new PreProcessPipeline(Enumerable.Empty<IPreProcessor>());
             var smidgeOptions = new Mock<IOptions<SmidgeOptions>>();
             smidgeOptions.Setup(opt => opt.Value).Returns(new SmidgeOptions());
@@ -58,9 +60,10 @@ namespace Smidge.Tests
 
             var fileProvider = new Mock<IFileProvider>();
             var cacheProvider = new Mock<ICacheFileSystem>();
+            var logger = new Mock<ILogger>();
             var fileProviderFilter = new DefaultFileProviderFilter();
 
-            var fileSystemHelper = new SmidgeFileSystem(fileProvider.Object, fileProviderFilter, cacheProvider.Object, Mock.Of<IWebsiteInfo>());
+            var fileSystemHelper = new SmidgeFileSystem(fileProvider.Object, fileProviderFilter, cacheProvider.Object, Mock.Of<IWebsiteInfo>(), logger.Object);
             var pipeline = new PreProcessPipeline(Enumerable.Empty<IPreProcessor>());
             var smidgeOptions = new Mock<IOptions<SmidgeOptions>>();
             smidgeOptions.Setup(opt => opt.Value).Returns(new SmidgeOptions());
@@ -89,9 +92,10 @@ namespace Smidge.Tests
 
             var fileProvider = new Mock<IFileProvider>();
             var cacheProvider = new Mock<ICacheFileSystem>();
+            var logger = new Mock<ILogger>();
             var fileProviderFilter = new DefaultFileProviderFilter();
 
-            var fileSystemHelper = new SmidgeFileSystem(fileProvider.Object, fileProviderFilter, cacheProvider.Object, Mock.Of<IWebsiteInfo>());
+            var fileSystemHelper = new SmidgeFileSystem(fileProvider.Object, fileProviderFilter, cacheProvider.Object, Mock.Of<IWebsiteInfo>(), logger.Object);
             var pipeline = new PreProcessPipeline(Enumerable.Empty<IPreProcessor>());
             var smidgeOptions = new Mock<IOptions<SmidgeOptions>>();
             smidgeOptions.Setup(opt => opt.Value).Returns(new SmidgeOptions());

--- a/test/Smidge.Tests/CssImportProcessorTests.cs
+++ b/test/Smidge.Tests/CssImportProcessorTests.cs
@@ -1,5 +1,6 @@
-﻿using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Logging;
 using Moq;
 using Smidge.Cache;
 using Smidge.FileProcessors;
@@ -69,7 +70,8 @@ div {display: block;}".Replace("\r\n", string.Empty).Replace("\n", string.Empty)
                 Mock.Of<IFileProvider>(),
                 Mock.Of<IFileProviderFilter>(),
                 Mock.Of<ICacheFileSystem>(),
-                Mock.Of<IWebsiteInfo>());
+                Mock.Of<IWebsiteInfo>(),
+                Mock.Of<ILogger>());
             return fileSystem;
         }
 

--- a/test/Smidge.Tests/FileBatcherTests.cs
+++ b/test/Smidge.Tests/FileBatcherTests.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Logging;
 using Xunit;
 using Smidge.Hashing;
 using Smidge.Cache;
@@ -28,10 +29,11 @@ namespace Smidge.Tests
 
             var fileProvider = new Mock<IFileProvider>();
             var cacheProvider = new Mock<ICacheFileSystem>();
+            var logger = new Mock<ILogger>();
             var fileProviderFilter = new DefaultFileProviderFilter();
 
             var hasher = Mock.Of<IHasher>();
-            var fileSystemHelper = new SmidgeFileSystem(fileProvider.Object, fileProviderFilter, cacheProvider.Object, Mock.Of<IWebsiteInfo>());
+            var fileSystemHelper = new SmidgeFileSystem(fileProvider.Object, fileProviderFilter, cacheProvider.Object, Mock.Of<IWebsiteInfo>(), logger.Object);
             var batcher = new FileBatcher(fileSystemHelper, urlHelper, hasher);
 
             var file = new Mock<IFileInfo>();
@@ -59,9 +61,10 @@ namespace Smidge.Tests
 
             var fileProvider = new Mock<IFileProvider>();
             var cacheProvider = new Mock<ICacheFileSystem>();
+            var logger = new Mock<ILogger>();
             var fileProviderFilter = new DefaultFileProviderFilter();
             var hasher = Mock.Of<IHasher>();
-            var fileSystemHelper = new SmidgeFileSystem(fileProvider.Object, fileProviderFilter, cacheProvider.Object, Mock.Of<IWebsiteInfo>());          
+            var fileSystemHelper = new SmidgeFileSystem(fileProvider.Object, fileProviderFilter, cacheProvider.Object, Mock.Of<IWebsiteInfo>(), logger.Object);          
             var batcher = new FileBatcher(fileSystemHelper, urlHelper, hasher);
 
             var file = new Mock<IFileInfo>();

--- a/test/Smidge.Tests/SmidgeHelperTests.cs
+++ b/test/Smidge.Tests/SmidgeHelperTests.cs
@@ -23,6 +23,7 @@ namespace Smidge.Tests
         private readonly IUrlManager _urlManager = Mock.Of<IUrlManager>();
         private readonly IFileProvider _fileProvider = Mock.Of<IFileProvider>();
         private readonly ICacheFileSystem _cacheProvider = Mock.Of<ICacheFileSystem>();
+        private readonly ILogger _logger = Mock.Of<ILogger>();
         private readonly IFileProviderFilter _fileProviderFilter = Mock.Of<IFileProviderFilter>();
         private readonly IHasher _hasher = Mock.Of<IHasher>();
         private readonly IEnumerable<IPreProcessor> _preProcessors = new List<IPreProcessor>();
@@ -46,7 +47,7 @@ namespace Smidge.Tests
             _httpContextAccessor.Setup(x => x.HttpContext).Returns(_httpContext.Object);
 
             _dynamicallyRegisteredWebFiles = new DynamicallyRegisteredWebFiles();
-            _fileSystemHelper = new SmidgeFileSystem(_fileProvider, _fileProviderFilter, _cacheProvider, Mock.Of<IWebsiteInfo>());
+            _fileSystemHelper = new SmidgeFileSystem(_fileProvider, _fileProviderFilter, _cacheProvider, Mock.Of<IWebsiteInfo>(), _logger);
             _smidgeOptions = new Mock<IOptions<SmidgeOptions>>();
             _smidgeOptions.Setup(opt => opt.Value).Returns(new SmidgeOptions
             {


### PR DESCRIPTION
Fixes #199.

- I added a logger on all applicable places in support of the reported issue. 
- Updated the unit test to check for a useful log-attempt instead of throwing an exception.
- Tested the implemention using Smidge.Web both with and without `AddSmidgeInMemory` and manipulating some of the generated `/sc`-URLs:
![image](https://github.com/Shazwazza/Smidge/assets/869973/4013d9fb-2e77-425a-b7db-f94bb8cb0687)

Upon testing, it looks like `/sb`-URLs could use a similar treatment as it will throw an exception when the bundle-key or version is invalid, but I'd say that's something for another PR.