### PR TITLE
Avoid CssMinifier stripping spaces that are followed by colons

### DIFF
--- a/src/Smidge.Core/FileProcessors/CssMinifier.cs
+++ b/src/Smidge.Core/FileProcessors/CssMinifier.cs
@@ -80,7 +80,6 @@ namespace Smidge.FileProcessors
                                 {
                                     case ' ':        //body.Replace("  ", String.Empty);
                                     case '{':        //body = body.Replace(" {", "{");
-                                    case ':':        //body = body.Replace(" {", "{");
                                     case '\n':       //body = body.Replace(" \n", "\n");
                                     case '\r':       //body = body.Replace(" \r", "\r");
                                     case '\t':       //body = body.Replace(" \t", "\t");

--- a/test/Smidge.Tests/CssMinTests.cs
+++ b/test/Smidge.Tests/CssMinTests.cs
@@ -135,5 +135,23 @@ audio:not([controls]) {
             
         }
 
+        [Fact]
+        public async Task CssMin_Ensure_Spaces_Not_Stripped_From_Complex_Selectors()
+        {
+            //refer to this: https://github.com/Shazwazza/Smidge/issues/139
+            //The problem is stripping spaces which are followed by a colon - that's not OK this type of selector
+
+            var css = ".prose :where([class~=lead]):not(:where([class~=not-prose] *)){}";
+
+            var minifier = new CssMinifier();
+            using (var bc = BundleContext.CreateEmpty("1"))
+            {
+                var fileProcessContext = new FileProcessContext(css, Mock.Of<IWebFile>(), bc);
+                await minifier.ProcessAsync(fileProcessContext, ctx => Task.FromResult(0));
+
+                Assert.Equal(css, fileProcessContext.FileContent);
+            }
+        }
+
     }
 }


### PR DESCRIPTION
Fixes #139

The CSS Minifier strips spaces if they're followed by a colon.   This is not safe for certain selectors, where maintaining the space is vital to separate the parts of the selector.   e.g.: `.classname :where([class~=otherclassname])`

This PR includes a new test (which was failing), and removes the clause that allows a space to be removed if it's followed by a colon. 
 This will reduce minification to some (probably small) extent, but improves correctness.   All existing tests still pass unmodified.

I have not tried, but I think that working out where exactly it is safe to remove `<space>:` might require a much more sophisticated minifier, with a much more detailed understanding of the CSS structure - my guess is that's not worth it.

