### PR TITLE
fix: no source set for link with preload as style

### DIFF
--- a/src/Smidge/TagHelpers/SmidgeLinkTagHelper.cs
+++ b/src/Smidge/TagHelpers/SmidgeLinkTagHelper.cs
@@ -77,7 +77,7 @@ namespace Smidge.TagHelpers
                 return;
             }
 
-            if (context.AllAttributes.TryGetAttribute("as", out TagHelperAttribute attribute) && attribute.Value is not "style")
+            if (context.AllAttributes.TryGetAttribute("as", out TagHelperAttribute attribute) && attribute.Value?.ToString() is not "style")
             {
                 return;
             }


### PR DESCRIPTION
The preload as style check was not working, cause it returned an htmlstring as an object, which results in `{style}` and not `style`. 

![image](https://github.com/user-attachments/assets/0e2ff5bb-7cce-496b-9df9-7c39598f0de2)
