### PR TITLE
Update dependencies to latest for v5 major release

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -12,7 +12,7 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.301" PrivateAssets="All"/>
   </ItemGroup>
   <PropertyGroup>
     <PackageProjectUrl>https://github.com/Shazwazza/Smidge</PackageProjectUrl>

--- a/src/Smidge.Core/Smidge.Core.csproj
+++ b/src/Smidge.Core/Smidge.Core.csproj
@@ -14,11 +14,11 @@
     <Content Include="..\..\assets\logo-nuget.png" Link="logo-nuget.png" Pack="true" PackagePath="" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Composite" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Composite" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.10" />
   </ItemGroup>
 </Project>

--- a/src/Smidge.Web/package.json
+++ b/src/Smidge.Web/package.json
@@ -3,6 +3,6 @@
   "version": "0.0.0",
   "private": true,
   "devDependencies": {
-    "uglify-js": "^2.7.0"
+    "uglify-js": "^3.19.3"
   }
 }

--- a/test/Smidge.Integration.Tests/Smidge.Integration.Tests.csproj
+++ b/test/Smidge.Integration.Tests/Smidge.Integration.Tests.csproj
@@ -19,12 +19,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit" Version="2.7.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Smidge.Tests/Smidge.Tests.csproj
+++ b/test/Smidge.Tests/Smidge.Tests.csproj
@@ -15,14 +15,13 @@
 
   <ItemGroup>
     <PackageReference Include="Dazinator.Extensions.FileProviders" Version="2.0.0" />
-    <PackageReference Include="xunit" Version="2.7.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="Moq" Version="4.20.70" />
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta4-build3742" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Since we're shipping a new major version, this bumps all NuGet and npm dependencies to their latest stable releases so v5 starts on a current baseline.

## Changes

- **Microsoft.SourceLink.GitHub** 8.0.0 -> 10.0.301
- **Microsoft.Extensions.*** (Configuration, Configuration.Json, FileProviders.Composite, Hosting.Abstractions, Logging.Abstractions, Options) 10.0.9 -> 10.0.10
- **xunit** 2.7.0 -> 2.9.3
- **xunit.runner.visualstudio** 2.5.7 -> 3.1.5
- **Microsoft.NET.Test.Sdk** 17.9.0 -> 18.8.1
- **Moq** 4.20.70 -> 4.20.72
- **uglify-js** (Web sample) ^2.7.0 -> ^3.19.3

## Notes

- Nuglify (1.22.0) and Dazinator.Extensions.FileProviders (2.0.0) were already on their latest stable versions; newer releases are prerelease only, so they were left untouched.
- Stayed on stable releases rather than the 11.0 previews, consistent with the repo already targeting stable `net10.0` packages.
- Removed the long-deprecated `dotnet-xunit` CLI tool reference while bumping xunit, since it is incompatible with modern xunit runners.

## Validation

Build succeeds with zero warnings (the repo has `TreatWarningsAsErrors` enabled) and all tests pass (65 unit + 24 integration = 89 total).